### PR TITLE
Add Windows start script

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,8 @@ python app.py
 
 Then open `http://localhost:5000` in a browser.
 
+On Windows, you can double-click `start.bat` to install dependencies, run the server, and open the app automatically.
+
 ## Adding tools
 
 1. Drop your executable scripts into the `scripts/` directory.

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Launch OmniTool
+cd /d "%~dp0"
+echo Installing dependencies...
+pip install -r requirements.txt
+start "OmniTool" python app.py
+timeout /t 3 > nul
+start "" http://localhost:5000


### PR DESCRIPTION
## Summary
- add `start.bat` so Windows users can launch OmniTool with a double-click
- document start script in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1b9cc4de48324a84e60088b2b665e