### PR TITLE
Add thumbnail previews to dual file renamer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0
+Pillow>=9.0


### PR DESCRIPTION
## Summary
- clarify directory picker titles
- show thumbnail previews for selected files in dual file renamer
- add Pillow dependency for image support

## Testing
- `python -m py_compile OmniTool/scripts/dual_file_renamer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab1cdb07ec8324b57b0a55ff1f9d0a