### PR TITLE
Add video thumbnail support to dual file renamer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=3.0
 Pillow>=9.0
+imageio>=2.0


### PR DESCRIPTION
## Summary
- show thumbnails for common image and video formats in both renamer panes
- preload first items so previews are immediately visible
- add imageio dependency for video frame extraction

## Testing
- `python -m py_compile scripts/dual_file_renamer.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1ec0e94c8324a0d665276a9442e8