### PR TITLE
Show thumbnails in dual file renamer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=3.0
 Pillow>=9.0
+opencv-python-headless>=4.8


### PR DESCRIPTION
## Summary
- Display thumbnails for each file in both source and destination lists
- Generate previews for images and videos with OpenCV; fallback placeholder when needed
- Add OpenCV dependency

## Testing
- `python -m py_compile scripts/dual_file_renamer.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Pillow>=9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1ec0e94c8324a0d665276a9442e8