### PR TITLE
Make llama-cpp optional dependency

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,18 @@ python app.py
 
 Then open `http://localhost:5000` in a browser.
 
+> **Optional local models**
+>
+> The Comfy Prompt Builder can talk to local GGUF models through
+> `llama-cpp-python`, but that package requires native build tools on
+> Windows. To keep the default setup lightweight, it's no longer installed
+> automatically. If you need local model support, install it manually after
+> setting up the project:
+>
+> ```bash
+> pip install llama-cpp-python
+> ```
+
 On Windows, you can double-click `start.bat` to install dependencies, run the server, and open the app automatically.
 
 ## Adding tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pymupdf>=1.23
 fastapi>=0.110
 uvicorn[standard]>=0.28
 requests>=2.31
-llama-cpp-python>=0.2.90


### PR DESCRIPTION
## Summary
- remove llama-cpp-python from the default requirements to avoid repeated heavy installs
- document how to manually install llama-cpp-python for optional local GGUF model support in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd843e84b08324b28ec85ceac7c405