### PR TITLE
Ensure start script isolates virtualenv

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,10 @@
 @echo off
 setlocal
 
+rem Ensure Python ignores user site-packages so installations stay isolated to the
+rem virtual environment and avoid permission issues with global packages.
+set PYTHONNOUSERSITE=1
+
 set "SCRIPT_DIR=%~dp0"
 cd /d "%SCRIPT_DIR%"
 set "VENV_DIR=%SCRIPT_DIR%.venv"


### PR DESCRIPTION
## Summary
- prevent Windows start script from loading user site-packages when installing dependencies
- set PYTHONNOUSERSITE so the virtual environment handles package management cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd87e9a8288324b55c5914a20d4f36