### PR TITLE
Ensure Windows start script isolates dependencies

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -6,6 +6,10 @@ cd /d "%SCRIPT_DIR%"
 set "VENV_DIR=%SCRIPT_DIR%.venv"
 set "PYTHON_EXE=%VENV_DIR%\Scripts\python.exe"
 
+rem Ensure installations always happen inside the virtual environment.
+set "PYTHONNOUSERSITE=1"
+set "PIP_USER=0"
+
 if not exist "%PYTHON_EXE%" (
     echo Creating virtual environment...
     py -3 -m venv "%VENV_DIR%" >nul 2>&1
@@ -22,9 +26,17 @@ if not exist "%PYTHON_EXE%" (
 
 echo Updating pip...
 "%PYTHON_EXE%" -m pip install --upgrade pip
+if errorlevel 1 (
+    echo Failed to update pip. See the messages above for details.
+    exit /b 1
+)
 
 echo Installing dependencies...
 "%PYTHON_EXE%" -m pip install -r requirements.txt
+if errorlevel 1 (
+    echo Failed to install dependencies. See the messages above for details.
+    exit /b 1
+)
 
 start "OmniTool" "%PYTHON_EXE%" app.py
 timeout /t 3 > nul


### PR DESCRIPTION
## Summary
- prevent user-level site-packages from being injected into the runtime used by `start.bat`
- add error handling so dependency installation failures stop the launcher early

## Testing
- Not run (Windows batch script changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd87e9a8288324b55c5914a20d4f36