### PR TITLE
Pin OpenCV dependency below numpy 2 requirement

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,16 @@ python app.py
 
 Then open `http://localhost:5000` in a browser.
 
+> **Windows permissions error installing numpy?**
+>
+> If you see an error such as `Could not install packages due to an OSError:
+> [WinError 2] The system cannot find the file specified: '...f2py.exe'`, it
+> means pip tried to upgrade a system-wide copy of NumPy. The included
+> `requirements.txt` now pins NumPy below version 2.0 and OpenCV below 4.11 to
+> avoid that upgrade, but you may still need to make sure you're installing
+> inside a virtual environment (the provided `start.bat` does this
+> automatically).
+
 > **Optional local models**
 >
 > The Comfy Prompt Builder can talk to local GGUF models through

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask>=3.0
 Pillow>=9.0
-opencv-python-headless>=4.8
+numpy>=1.24,<2.0
+opencv-python-headless>=4.8,<4.11
 pymupdf>=1.23
 fastapi>=0.110
 uvicorn[standard]>=0.28


### PR DESCRIPTION
## Summary
- pin OpenCV to pre-4.11 releases and add an explicit numpy<2.0 requirement so pip no longer forces a system-wide numpy upgrade
- document the Windows f2py.exe WinError 2 installer failure and note that the bundled dependency pins plus the virtual environment in start.bat avoid it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8a3f13e8832485f6f5bf79d613ea