### PR TITLE
Fix comfy prompt builder module import

### DIFF
--- a/scripts/comfy_prompt_builder/start.py
+++ b/scripts/comfy_prompt_builder/start.py
@@ -2,11 +2,22 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import sys
 import threading
 import time
 import webbrowser
 
 import uvicorn
+
+
+def _ensure_package_on_path() -> None:
+    """Ensure the comfy_prompt_builder package can be imported."""
+    package_dir = pathlib.Path(__file__).resolve().parent
+    parent_dir = package_dir.parent
+    parent_str = str(parent_dir)
+    if parent_str not in sys.path:
+        sys.path.insert(0, parent_str)
 
 PORT = int(os.getenv("COMFY_PROMPT_PORT", "8070"))
 HOST = os.getenv("COMFY_PROMPT_HOST", "127.0.0.1")
@@ -22,6 +33,7 @@ def _open_browser(url: str) -> None:
 
 
 def main() -> None:
+    _ensure_package_on_path()
     display_host = "127.0.0.1" if HOST == "0.0.0.0" else HOST
     url = f"http://{display_host}:{PORT}"
     if AUTO_OPEN:


### PR DESCRIPTION
## Summary
- ensure the `scripts` directory is added to `sys.path` before launching uvicorn
- make the Comfy Prompt Builder server importable when launched through OmniTool

## Testing
- `python scripts/comfy_prompt_builder/start.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd8ecd26e88324a9731fc28b1fca6f