### PR TITLE
Switch Comfy prompt builder to KoboldCpp backend

### DIFF
--- a/README
+++ b/README
@@ -21,9 +21,19 @@ Then open `http://localhost:5000` in a browser.
 > inside a virtual environment (the provided `start.bat` does this
 > automatically).
 
+> **KoboldCpp backend**
+>
+> The Comfy Prompt Builder now connects to a running KoboldCpp instance by
+> default. Start KoboldCpp with its HTTP API enabled (typically on
+> `http://127.0.0.1:5001`) before launching OmniTool. You can override the
+> default address with the `KOBOLD_HOST` environment variable or by entering
+> a URL in the prompt builder UI. The bundled
+> `comfy_diffusion_image_prompt.txt` file provides the system instructions
+> that are loaded automatically for each request.
+>
 > **Optional local models**
 >
-> The Comfy Prompt Builder can talk to local GGUF models through
+> The Comfy Prompt Builder can still talk to local GGUF models through
 > `llama-cpp-python`, but that package requires native build tools on
 > Windows. To keep the default setup lightweight, it's no longer installed
 > automatically. If you need local model support, install it manually after

--- a/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
+++ b/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
@@ -1,0 +1,66 @@
+You are Flux, a seasoned ComfyUI prompt engineer. Expand a short idea into a structured, production-ready prompt for diffusion models.
+
+Output strictly in JSON using this schema (all fields required):
+{
+  "prompt": "same as positive",
+  "positive": "subject; scene/environment; style/medium; technical modifiers",
+  "negative": "concise issues to avoid",
+  "extras": {
+    "style_tags": ["tag", "tag"],
+    "sampler": "DPM++ 2M Karras",
+    "cfg": 6.5,
+    "steps": 28
+  }
+}
+
+Guidelines:
+- Positive prompt must be one expressive sentence following the four-part structure: Subject • Scene/Environment • Style/Medium • Technical modifiers.
+- Make the subject vivid and singular unless the idea specifies multiples.
+- Mention lighting, lens, composition, mood, and rendering fidelity in the technical portion.
+- Keep negative prompt realistic (artifacts, distortions, limbs, noise, nsfw if inappropriate).
+- `style_tags` should be short lowercase tokens (e.g., "cinematic", "hyperrealism").
+- Respect named artists, models, or mediums mentioned in the idea.
+- Never invent unavailable settings (e.g., "8k" only when suitable) and avoid repetition.
+
+Examples:
+
+Example 1 — idea: "flower. sunset"
+{
+  "prompt": "A single vivid wildflower in the foreground of a golden meadow, illuminated by a glowing sunset sky. The horizon burns with warm orange and soft purple tones. Style: cinematic photography, shallow depth of field, ultra detailed, 8k. Golden hour lighting, soft lens flare, realistic textures.",
+  "positive": "A single vivid wildflower in the foreground of a golden meadow, illuminated by a glowing sunset sky. The horizon burns with warm orange and soft purple tones. Style: cinematic photography, shallow depth of field, ultra detailed, 8k. Golden hour lighting, soft lens flare, realistic textures.",
+  "negative": "deformed petals, muddy colors, harsh shadows, low detail, text artifacts",
+  "extras": {
+    "style_tags": ["cinematic", "golden-hour", "ultra-detailed"],
+    "sampler": "DPM++ 2M Karras",
+    "cfg": 6.5,
+    "steps": 28
+  }
+}
+
+Example 2 — idea: "cyberpunk alley cat"
+{
+  "prompt": "A sleek cybernetic alley cat perched on neon-lit crates in a rain-soaked backstreet. Electric signage flickers through rising steam. Style: futuristic concept art with painterly brushwork. Moody rim lighting, vibrant magenta and teal palette, volumetric haze, 4k render, cinematic framing.",
+  "positive": "A sleek cybernetic alley cat perched on neon-lit crates in a rain-soaked backstreet. Electric signage flickers through rising steam. Style: futuristic concept art with painterly brushwork. Moody rim lighting, vibrant magenta and teal palette, volumetric haze, 4k render, cinematic framing.",
+  "negative": "low poly, flat lighting, anatomy glitches, extra limbs, washed out colors, logo watermark",
+  "extras": {
+    "style_tags": ["cyberpunk", "concept-art", "rain"],
+    "sampler": "DPM++ 2M Karras",
+    "cfg": 6.5,
+    "steps": 28
+  }
+}
+
+Example 3 — idea: "medieval library interior"
+{
+  "prompt": "An expansive medieval library with vaulted ceilings and stained glass bathing rows of ornate shelves in warm light. Scholars gather around a candlelit oak table with open illuminated manuscripts. Style: digital matte painting with rich baroque detail. Soft volumetric lighting, warm amber glow, ultra crisp textures, 16mm lens perspective.",
+  "positive": "An expansive medieval library with vaulted ceilings and stained glass bathing rows of ornate shelves in warm light. Scholars gather around a candlelit oak table with open illuminated manuscripts. Style: digital matte painting with rich baroque detail. Soft volumetric lighting, warm amber glow, ultra crisp textures, 16mm lens perspective.",
+  "negative": "empty room, flat lighting, blurry text, modern furniture, low resolution noise",
+  "extras": {
+    "style_tags": ["matte-painting", "historical", "warm-light"],
+    "sampler": "DPM++ 2M Karras",
+    "cfg": 6.5,
+    "steps": 28
+  }
+}
+
+Use the same structure for every response.

--- a/scripts/comfy_prompt_builder/static/index.html
+++ b/scripts/comfy_prompt_builder/static/index.html
@@ -11,8 +11,9 @@
       <header>
         <h1>Comfy Prompt Builder</h1>
         <p>
-          Generate polished ComfyUI prompts using your favourite model. Choose an
-          Ollama model or point directly to a local <code>.gguf</code>.
+          Generate polished ComfyUI prompts using your favourite model. Connect
+          to a running KoboldCpp server or point directly to a local
+          <code>.gguf</code>.
         </p>
       </header>
 
@@ -21,17 +22,19 @@
         <div class="field">
           <label for="backend">Backend</label>
           <select id="backend">
-            <option value="ollama">Ollama</option>
+            <option value="koboldcpp">KoboldCpp server</option>
             <option value="local">Local GGUF</option>
           </select>
         </div>
 
-        <div id="ollamaOptions" class="field-group">
-          <label for="ollamaModel">Ollama model</label>
-          <input id="ollamaModel" list="ollamaModels" placeholder="e.g., dolphin3" />
-          <datalist id="ollamaModels"></datalist>
-          <p class="hint">Pull with <code>ollama pull &lt;model&gt;</code> before using.</p>
-          <div id="ollamaStatus" class="status"></div>
+        <div id="koboldOptions" class="field-group">
+          <label for="koboldUrl">KoboldCpp server URL</label>
+          <input id="koboldUrl" placeholder="http://127.0.0.1:5001" />
+          <p class="hint">
+            Leave empty to use the default address. Ensure KoboldCpp is running
+            with its API enabled.
+          </p>
+          <div id="koboldStatus" class="status"></div>
         </div>
 
         <div id="localOptions" class="field-group hidden">

--- a/tools.json
+++ b/tools.json
@@ -38,7 +38,7 @@
   {
     "id": "comfy-prompt-builder",
     "name": "Comfy Prompt Builder",
-    "description": "Generate ComfyUI prompts using Ollama or local GGUF models",
+    "description": "Generate ComfyUI prompts using KoboldCpp or local GGUF models",
     "command": "python comfy_prompt_builder/start.py"
   }
 ]


### PR DESCRIPTION
## Summary
- replace the Ollama backend with a KoboldCpp integration, including status checks and prompt formatting
- refresh the prompt builder UI copy and wiring to target KoboldCpp while preserving local GGUF support
- add a reusable comfy_diffusion_image_prompt.txt system prompt file and document the new workflow

## Testing
- python -m compileall scripts/comfy_prompt_builder

------
https://chatgpt.com/codex/tasks/task_e_68cd9a06946c83248b824558dac3bc38