### PR TITLE
Refocus Flux prompt builder on prompt-only output

### DIFF
--- a/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
+++ b/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
@@ -1,66 +1,22 @@
-You are Flux, a seasoned ComfyUI prompt engineer. Expand a short idea into a structured, production-ready prompt for diffusion models.
+You are Flux, a seasoned prompt engineer for FLUX.1 text-to-image models. Expand any short, unstructured idea into a polished Flux prompt.
 
-Output strictly in JSON using this schema (all fields required):
-{
-  "prompt": "same as positive",
-  "positive": "subject; scene/environment; style/medium; technical modifiers",
-  "negative": "concise issues to avoid",
-  "extras": {
-    "style_tags": ["tag", "tag"],
-    "sampler": "DPM++ 2M Karras",
-    "cfg": 6.5,
-    "steps": 28
-  }
-}
+Return a single text string—no JSON, bullet lists, code fences, or parameter blocks. Write a cohesive prompt that clearly covers four parts in order:
+1. Subject – Identify the focus of the image with vivid specificity.
+2. Scene / Environment – Describe the setting, atmosphere, or surrounding action.
+3. Style / Medium – Indicate the artistic treatment, camera approach, or medium.
+4. Technical modifiers – Add lighting, mood, lens, composition, texture, or resolution cues.
 
-Guidelines:
-- Positive prompt must be one expressive sentence following the four-part structure: Subject • Scene/Environment • Style/Medium • Technical modifiers.
-- Make the subject vivid and singular unless the idea specifies multiples.
-- Mention lighting, lens, composition, mood, and rendering fidelity in the technical portion.
-- Keep negative prompt realistic (artifacts, distortions, limbs, noise, nsfw if inappropriate).
-- `style_tags` should be short lowercase tokens (e.g., "cinematic", "hyperrealism").
-- Respect named artists, models, or mediums mentioned in the idea.
-- Never invent unavailable settings (e.g., "8k" only when suitable) and avoid repetition.
+Blend these parts into flowing sentences separated by periods. Never mention or infer samplers, CFG, steps, seeds, aspect ratios, or other generation parameters. Keep the language punchy, avoid repetition, and honour any artists, styles, or materials referenced by the user.
 
 Examples:
+Idea: "flower. sunset"
+Prompt:
+A single vivid wildflower standing tall in the foreground of a golden meadow at dusk. The horizon glows with warm orange and lavender clouds while distant hills fade into soft haze. Style: cinematic photography with shallow depth of field and tactile macro detail. Technical: golden hour glow, gentle lens flare, creamy bokeh, ultra crisp textures, 8k clarity.
 
-Example 1 — idea: "flower. sunset"
-{
-  "prompt": "A single vivid wildflower in the foreground of a golden meadow, illuminated by a glowing sunset sky. The horizon burns with warm orange and soft purple tones. Style: cinematic photography, shallow depth of field, ultra detailed, 8k. Golden hour lighting, soft lens flare, realistic textures.",
-  "positive": "A single vivid wildflower in the foreground of a golden meadow, illuminated by a glowing sunset sky. The horizon burns with warm orange and soft purple tones. Style: cinematic photography, shallow depth of field, ultra detailed, 8k. Golden hour lighting, soft lens flare, realistic textures.",
-  "negative": "deformed petals, muddy colors, harsh shadows, low detail, text artifacts",
-  "extras": {
-    "style_tags": ["cinematic", "golden-hour", "ultra-detailed"],
-    "sampler": "DPM++ 2M Karras",
-    "cfg": 6.5,
-    "steps": 28
-  }
-}
+Idea: "snowy mountain cabin"
+Prompt:
+A hand-built log cabin with smoke curling from the chimney nestled beside frost-laden pines. Moonlight reflects off untouched alpine snowdrifts and a star-studded peak towering behind. Style: hyperreal winter landscape photography with subtle film grain. Technical: midnight blue palette, long exposure shimmer, wide-angle composition, crystalline highlights, 8k definition.
 
-Example 2 — idea: "cyberpunk alley cat"
-{
-  "prompt": "A sleek cybernetic alley cat perched on neon-lit crates in a rain-soaked backstreet. Electric signage flickers through rising steam. Style: futuristic concept art with painterly brushwork. Moody rim lighting, vibrant magenta and teal palette, volumetric haze, 4k render, cinematic framing.",
-  "positive": "A sleek cybernetic alley cat perched on neon-lit crates in a rain-soaked backstreet. Electric signage flickers through rising steam. Style: futuristic concept art with painterly brushwork. Moody rim lighting, vibrant magenta and teal palette, volumetric haze, 4k render, cinematic framing.",
-  "negative": "low poly, flat lighting, anatomy glitches, extra limbs, washed out colors, logo watermark",
-  "extras": {
-    "style_tags": ["cyberpunk", "concept-art", "rain"],
-    "sampler": "DPM++ 2M Karras",
-    "cfg": 6.5,
-    "steps": 28
-  }
-}
-
-Example 3 — idea: "medieval library interior"
-{
-  "prompt": "An expansive medieval library with vaulted ceilings and stained glass bathing rows of ornate shelves in warm light. Scholars gather around a candlelit oak table with open illuminated manuscripts. Style: digital matte painting with rich baroque detail. Soft volumetric lighting, warm amber glow, ultra crisp textures, 16mm lens perspective.",
-  "positive": "An expansive medieval library with vaulted ceilings and stained glass bathing rows of ornate shelves in warm light. Scholars gather around a candlelit oak table with open illuminated manuscripts. Style: digital matte painting with rich baroque detail. Soft volumetric lighting, warm amber glow, ultra crisp textures, 16mm lens perspective.",
-  "negative": "empty room, flat lighting, blurry text, modern furniture, low resolution noise",
-  "extras": {
-    "style_tags": ["matte-painting", "historical", "warm-light"],
-    "sampler": "DPM++ 2M Karras",
-    "cfg": 6.5,
-    "steps": 28
-  }
-}
-
-Use the same structure for every response.
+Idea: "retro-futuristic city skyline"
+Prompt:
+A sweeping skyline of retro-futuristic skyscrapers crowned with chrome spires and neon billboards. Elevated highways weave between hovering transit pods above a sunset-lit harbor. Style: vibrant digital illustration blending art deco and synthwave aesthetics. Technical: magenta and cyan bloom lighting, atmospheric haze, cinematic framing, ultra detailed reflections, 32mm lens perspective.

--- a/scripts/comfy_prompt_builder/server.py
+++ b/scripts/comfy_prompt_builder/server.py
@@ -38,17 +38,36 @@ def _load_system_prompt() -> str:
         except OSError:
             pass
     return (
-        "You are a prompt engineer for Stable Diffusion (ComfyUI). "
-        "Transform a short idea into a clean SD/ComfyUI prompt.\n"
-        "Output JSON with fields:\n"
-        "{\n"
-        '  "positive": "comma-separated descriptive prompt",\n'
-        '  "negative": "things to avoid, artifacts",\n'
-        '  "extras": { "style_tags": [], "sampler": "DPM++ 2M Karras", "cfg": 6.5, "steps": 28 }\n'
-        "}\n"
-        "Rules: concise, powerful tags; include subject, composition, lighting, lens/camera, style; "
-        "avoid repetition; keep negative realistic. If the idea names a model, tag appropriately.\n"
-        "Also include a flat string field 'prompt' equal to positive."
+        "You are Flux, a seasoned prompt engineer for FLUX.1 text-to-image models. "
+        "Expand any short, unstructured idea into a polished Flux prompt.\n\n"
+        "Return a single text string—no JSON, bullet lists, code fences, or parameter blocks. "
+        "Write a cohesive prompt that clearly covers four parts in order:\n"
+        "1. Subject – Identify the focus of the image with vivid specificity.\n"
+        "2. Scene / Environment – Describe the setting, atmosphere, or surrounding action.\n"
+        "3. Style / Medium – Indicate the artistic treatment, camera approach, or medium.\n"
+        "4. Technical modifiers – Add lighting, mood, lens, composition, texture, or resolution cues.\n\n"
+        "Blend these parts into flowing sentences separated by periods. "
+        "Never mention or infer samplers, CFG, steps, seeds, aspect ratios, or other generation parameters. "
+        "Keep the language punchy, avoid repetition, and honour any artists, styles, or materials referenced by the user.\n\n"
+        "Examples:\n"
+        "Idea: \"flower. sunset\"\n"
+        "Prompt:\n"
+        "A single vivid wildflower standing tall in the foreground of a golden meadow at dusk. "
+        "The horizon glows with warm orange and lavender clouds while distant hills fade into soft haze. "
+        "Style: cinematic photography with shallow depth of field and tactile macro detail. "
+        "Technical: golden hour glow, gentle lens flare, creamy bokeh, ultra crisp textures, 8k clarity.\n\n"
+        "Idea: \"snowy mountain cabin\"\n"
+        "Prompt:\n"
+        "A hand-built log cabin with smoke curling from the chimney nestled beside frost-laden pines. "
+        "Moonlight reflects off untouched alpine snowdrifts and a star-studded peak towering behind. "
+        "Style: hyperreal winter landscape photography with subtle film grain. "
+        "Technical: midnight blue palette, long exposure shimmer, wide-angle composition, crystalline highlights, 8k definition.\n\n"
+        "Idea: \"retro-futuristic city skyline\"\n"
+        "Prompt:\n"
+        "A sweeping skyline of retro-futuristic skyscrapers crowned with chrome spires and neon billboards. "
+        "Elevated highways weave between hovering transit pods above a sunset-lit harbor. "
+        "Style: vibrant digital illustration blending art deco and synthwave aesthetics. "
+        "Technical: magenta and cyan bloom lighting, atmospheric haze, cinematic framing, ultra detailed reflections, 32mm lens perspective."
     )
 
 

--- a/scripts/comfy_prompt_builder/static/app.js
+++ b/scripts/comfy_prompt_builder/static/app.js
@@ -8,12 +8,7 @@ const localStatus = $('#localStatus');
 const ggufInput = $('#ggufPath');
 const generateBtn = $('#generate');
 const resultBox = $('#result');
-const parsedBox = $('#parsed');
-const positiveBox = $('#positive');
-const negativeBox = $('#negative');
-const extrasBox = $('#extras');
-const copyJsonBtn = $('#copyJson');
-const copyPositiveBtn = $('#copyPositive');
+const copyPromptBtn = $('#copyPrompt');
 const browseBtn = $('#browse');
 const fileBrowser = $('#fileBrowser');
 const closeBrowserBtn = $('#closeBrowser');
@@ -99,26 +94,11 @@ function switchBackend(value) {
 
 function resetResult() {
   resultBox.textContent = 'Generating…';
-  parsedBox.classList.add('hidden');
-  positiveBox.textContent = '';
-  negativeBox.textContent = '';
-  extrasBox.textContent = '';
 }
 
 function renderResult(content) {
   state.lastResponse = content;
   resultBox.textContent = content;
-  try {
-    const parsed = JSON.parse(content);
-    positiveBox.textContent = parsed.prompt || parsed.positive || '';
-    negativeBox.textContent = parsed.negative || '';
-    extrasBox.textContent = parsed.extras ? JSON.stringify(parsed.extras, null, 2) : '';
-    parsedBox.classList.remove('hidden');
-    state.lastJson = parsed;
-  } catch (error) {
-    parsedBox.classList.add('hidden');
-    state.lastJson = null;
-  }
 }
 
 async function generate() {
@@ -176,16 +156,8 @@ function copyToClipboard(text) {
   });
 }
 
-function copyJson() {
+function copyPrompt() {
   if (state.lastResponse) {
-    copyToClipboard(state.lastResponse);
-  }
-}
-
-function copyPositive() {
-  if (state.lastJson) {
-    copyToClipboard(state.lastJson.prompt || state.lastJson.positive || '');
-  } else if (state.lastResponse) {
     copyToClipboard(state.lastResponse);
   }
 }
@@ -268,8 +240,7 @@ backendSelect.addEventListener('change', (event) => {
 });
 
 generateBtn.addEventListener('click', generate);
-copyJsonBtn.addEventListener('click', copyJson);
-copyPositiveBtn.addEventListener('click', copyPositive);
+copyPromptBtn.addEventListener('click', copyPrompt);
 browseBtn.addEventListener('click', () => showBrowser(state.browserPath));
 closeBrowserBtn.addEventListener('click', hideBrowser);
 fileBrowser.addEventListener('click', (event) => {

--- a/scripts/comfy_prompt_builder/static/index.html
+++ b/scripts/comfy_prompt_builder/static/index.html
@@ -3,19 +3,66 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Comfy Prompt Builder</title>
+    <title>Flux Prompt Builder</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div class="layout">
       <header>
-        <h1>Comfy Prompt Builder</h1>
+        <h1>Flux Prompt Builder</h1>
         <p>
-          Generate polished ComfyUI prompts using your favourite model. Connect
-          to a running KoboldCpp server or point directly to a local
-          <code>.gguf</code>.
+          Turn a quick idea into a fully-formed Flux prompt. This tool focuses
+          exclusively on the prompt text—no image parameters, no samplers, no
+          CFG values. Connect to a running KoboldCpp server or point directly to
+          a local <code>.gguf</code> model.
         </p>
       </header>
+
+      <section class="panel">
+        <h2>Prompt format</h2>
+        <p class="hint">
+          The model expands every idea into four flowing sentences covering the
+          subject, scene/environment, style/medium, and technical modifiers.
+          Expect a single text string with descriptions only—never parameter
+          blocks or JSON.
+        </p>
+        <div class="examples-list">
+          <article>
+            <h3>Idea: flower. sunset</h3>
+            <p>
+              A single vivid wildflower standing tall in the foreground of a
+              golden meadow at dusk. The horizon glows with warm orange and
+              lavender clouds while distant hills fade into soft haze. Style:
+              cinematic photography with shallow depth of field and tactile
+              macro detail. Technical: golden hour glow, gentle lens flare,
+              creamy bokeh, ultra crisp textures, 8k clarity.
+            </p>
+          </article>
+          <article>
+            <h3>Idea: snowy mountain cabin</h3>
+            <p>
+              A hand-built log cabin with smoke curling from the chimney nestled
+              beside frost-laden pines. Moonlight reflects off untouched alpine
+              snowdrifts and a star-studded peak towering behind. Style:
+              hyperreal winter landscape photography with subtle film grain.
+              Technical: midnight blue palette, long exposure shimmer,
+              wide-angle composition, crystalline highlights, 8k definition.
+            </p>
+          </article>
+          <article>
+            <h3>Idea: retro-futuristic city skyline</h3>
+            <p>
+              A sweeping skyline of retro-futuristic skyscrapers crowned with
+              chrome spires and neon billboards. Elevated highways weave between
+              hovering transit pods above a sunset-lit harbor. Style: vibrant
+              digital illustration blending art deco and synthwave aesthetics.
+              Technical: magenta and cyan bloom lighting, atmospheric haze,
+              cinematic framing, ultra detailed reflections, 32mm lens
+              perspective.
+            </p>
+          </article>
+        </div>
+      </section>
 
       <section class="panel">
         <h2>Model Source</h2>
@@ -105,23 +152,8 @@
       <section class="panel">
         <h2>Result</h2>
         <div id="result" class="result">No generation yet.</div>
-        <div id="parsed" class="parsed hidden">
-          <div>
-            <h3>Positive</h3>
-            <pre id="positive"></pre>
-          </div>
-          <div>
-            <h3>Negative</h3>
-            <pre id="negative"></pre>
-          </div>
-          <div>
-            <h3>Extras</h3>
-            <pre id="extras"></pre>
-          </div>
-        </div>
         <div class="actions">
-          <button id="copyJson" type="button">Copy JSON</button>
-          <button id="copyPositive" type="button">Copy positive</button>
+          <button id="copyPrompt" type="button">Copy prompt</button>
         </div>
       </section>
     </div>

--- a/scripts/comfy_prompt_builder/static/styles.css
+++ b/scripts/comfy_prompt_builder/static/styles.css
@@ -122,25 +122,40 @@ button.primary:hover {
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
-.parsed {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 12px;
-  margin: 16px 0;
-}
-
-.parsed pre {
-  background: rgba(8, 9, 12, 0.85);
-  border-radius: 10px;
-  padding: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
-}
-
 .actions {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.examples-list {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 12px;
+}
+
+.examples-list article {
+  background: rgba(15, 18, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.examples-list h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #9fc7ff;
+}
+
+.examples-list p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #d5d9e5;
+  line-height: 1.55;
 }
 
 .hint {


### PR DESCRIPTION
## Summary
- update the default Flux system prompt to demand text-only responses and include three reference examples
- refresh the web UI to highlight the prompt-only workflow and show example idea-to-prompt expansions
- simplify front-end handling so results are treated strictly as plain text prompts

## Testing
- python -m compileall scripts/comfy_prompt_builder

------
https://chatgpt.com/codex/tasks/task_e_68cd9fae68048324982a09898a37748b