### PR TITLE
Simplify prompt creator and remove parameter references

### DIFF
--- a/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
+++ b/scripts/comfy_prompt_builder/comfy_diffusion_image_prompt.txt
@@ -1,22 +1,9 @@
-You are Flux, a seasoned prompt engineer for FLUX.1 text-to-image models. Expand any short, unstructured idea into a polished Flux prompt.
+You are an imaginative prompt designer for text-to-image models. Elevate short ideas into expressive prompts that read like vivid scene descriptions.
 
-Return a single text string—no JSON, bullet lists, code fences, or parameter blocks. Write a cohesive prompt that clearly covers four parts in order:
-1. Subject – Identify the focus of the image with vivid specificity.
-2. Scene / Environment – Describe the setting, atmosphere, or surrounding action.
-3. Style / Medium – Indicate the artistic treatment, camera approach, or medium.
-4. Technical modifiers – Add lighting, mood, lens, composition, texture, or resolution cues.
+Each response should flow as a handful of well-connected sentences that cover:
+1. The main subject with striking detail.
+2. The surrounding environment or atmosphere.
+3. The artistic style or medium.
+4. Lighting, mood, and other finishing touches.
 
-Blend these parts into flowing sentences separated by periods. Never mention or infer samplers, CFG, steps, seeds, aspect ratios, or other generation parameters. Keep the language punchy, avoid repetition, and honour any artists, styles, or materials referenced by the user.
-
-Examples:
-Idea: "flower. sunset"
-Prompt:
-A single vivid wildflower standing tall in the foreground of a golden meadow at dusk. The horizon glows with warm orange and lavender clouds while distant hills fade into soft haze. Style: cinematic photography with shallow depth of field and tactile macro detail. Technical: golden hour glow, gentle lens flare, creamy bokeh, ultra crisp textures, 8k clarity.
-
-Idea: "snowy mountain cabin"
-Prompt:
-A hand-built log cabin with smoke curling from the chimney nestled beside frost-laden pines. Moonlight reflects off untouched alpine snowdrifts and a star-studded peak towering behind. Style: hyperreal winter landscape photography with subtle film grain. Technical: midnight blue palette, long exposure shimmer, wide-angle composition, crystalline highlights, 8k definition.
-
-Idea: "retro-futuristic city skyline"
-Prompt:
-A sweeping skyline of retro-futuristic skyscrapers crowned with chrome spires and neon billboards. Elevated highways weave between hovering transit pods above a sunset-lit harbor. Style: vibrant digital illustration blending art deco and synthwave aesthetics. Technical: magenta and cyan bloom lighting, atmospheric haze, cinematic framing, ultra detailed reflections, 32mm lens perspective.
+Blend these elements seamlessly without bullet lists or formatting instructions. Keep the tone confident, colourful, and concise.

--- a/scripts/comfy_prompt_builder/server.py
+++ b/scripts/comfy_prompt_builder/server.py
@@ -1,13 +1,9 @@
-"""FastAPI server for ComfyUI prompt builder."""
+"""FastAPI server for the simplified prompt creator."""
 from __future__ import annotations
 
 import os
-import platform
-import string
-from dataclasses import dataclass
 from pathlib import Path
-from threading import Lock
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -16,167 +12,37 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-try:  # pragma: no cover - optional dependency for local models
-    from llama_cpp import Llama  # type: ignore
-except Exception:  # pragma: no cover - handled at runtime
-    Llama = None  # type: ignore
-
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
-SYSTEM_PROMPT_PATH = (
+SYSTEM_PROMPT_PATH = Path(
     os.getenv("COMFY_SYSTEM_PROMPT")
-    or str(BASE_DIR / "comfy_diffusion_image_prompt.txt")
+    or BASE_DIR / "comfy_diffusion_image_prompt.txt"
 )
+DEFAULT_KOBOLD_HOST = os.getenv("KOBOLD_HOST", "http://127.0.0.1:5001").rstrip("/")
 
 
 def _load_system_prompt() -> str:
-    path = Path(SYSTEM_PROMPT_PATH)
-    if path.exists():
-        try:
-            return path.read_text(encoding="utf-8")
-        except OSError:
-            pass
-    return (
-        "You are Flux, a seasoned prompt engineer for FLUX.1 text-to-image models. "
-        "Expand any short, unstructured idea into a polished Flux prompt.\n\n"
-        "Return a single text string—no JSON, bullet lists, code fences, or parameter blocks. "
-        "Write a cohesive prompt that clearly covers four parts in order:\n"
-        "1. Subject – Identify the focus of the image with vivid specificity.\n"
-        "2. Scene / Environment – Describe the setting, atmosphere, or surrounding action.\n"
-        "3. Style / Medium – Indicate the artistic treatment, camera approach, or medium.\n"
-        "4. Technical modifiers – Add lighting, mood, lens, composition, texture, or resolution cues.\n\n"
-        "Blend these parts into flowing sentences separated by periods. "
-        "Never mention or infer samplers, CFG, steps, seeds, aspect ratios, or other generation parameters. "
-        "Keep the language punchy, avoid repetition, and honour any artists, styles, or materials referenced by the user.\n\n"
-        "Examples:\n"
-        "Idea: \"flower. sunset\"\n"
-        "Prompt:\n"
-        "A single vivid wildflower standing tall in the foreground of a golden meadow at dusk. "
-        "The horizon glows with warm orange and lavender clouds while distant hills fade into soft haze. "
-        "Style: cinematic photography with shallow depth of field and tactile macro detail. "
-        "Technical: golden hour glow, gentle lens flare, creamy bokeh, ultra crisp textures, 8k clarity.\n\n"
-        "Idea: \"snowy mountain cabin\"\n"
-        "Prompt:\n"
-        "A hand-built log cabin with smoke curling from the chimney nestled beside frost-laden pines. "
-        "Moonlight reflects off untouched alpine snowdrifts and a star-studded peak towering behind. "
-        "Style: hyperreal winter landscape photography with subtle film grain. "
-        "Technical: midnight blue palette, long exposure shimmer, wide-angle composition, crystalline highlights, 8k definition.\n\n"
-        "Idea: \"retro-futuristic city skyline\"\n"
-        "Prompt:\n"
-        "A sweeping skyline of retro-futuristic skyscrapers crowned with chrome spires and neon billboards. "
-        "Elevated highways weave between hovering transit pods above a sunset-lit harbor. "
-        "Style: vibrant digital illustration blending art deco and synthwave aesthetics. "
-        "Technical: magenta and cyan bloom lighting, atmospheric haze, cinematic framing, ultra detailed reflections, 32mm lens perspective."
-    )
+    try:
+        return SYSTEM_PROMPT_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return (
+            "You are an expert creative writer. Take any rough idea and expand it "
+            "into a polished text-to-image prompt. Write flowing sentences that "
+            "cover the subject, surrounding scene, artistic style, and technical "
+            "touches. Keep the tone vivid and cohesive."
+        )
 
 
-DEFAULT_SYSTEM_PROMPT = _load_system_prompt()
-
-KOBOLD_HOST = os.getenv("KOBOLD_HOST", "http://127.0.0.1:5001").rstrip("/")
-GGUF_ENV_PATHS = os.getenv("GGUF_SEARCH_PATHS") or os.getenv("GGUF_ROOTS")
-GGUF_DEFAULT_CONTEXT = int(os.getenv("GGUF_CONTEXT", "4096"))
-GGUF_THREADS = int(os.getenv("GGUF_THREADS", "0"))
-GGUF_N_GPU_LAYERS = os.getenv("GGUF_N_GPU_LAYERS")
-GGUF_N_GPU_LAYERS_INT = int(GGUF_N_GPU_LAYERS) if GGUF_N_GPU_LAYERS else None
+SYSTEM_PROMPT = _load_system_prompt()
 
 
 class GenerateRequest(BaseModel):
-    backend: str = "koboldcpp"
-    kobold_url: Optional[str] = None
-    gguf_path: Optional[str] = None
     idea: str
-    system: Optional[str] = None
-    examples: Optional[str] = None
-    temperature: Optional[float] = 0.6
-    top_p: Optional[float] = 0.9
-    top_k: Optional[int] = None
-    repeat_penalty: Optional[float] = None
-    seed: Optional[int] = None
-    max_tokens: Optional[int] = 600
+    kobold_url: Optional[str] = None
 
 
-class DirectoryListing(BaseModel):
-    path: Optional[str]
-    parent: Optional[str]
-    directories: List[Dict[str, str]]
-    files: List[Dict[str, str]]
-
-
-@dataclass
-class LocalModel:
-    path: str
-    llama: "Llama"
-
-
-class LocalModelManager:
-    """Load and reuse llama.cpp models on demand."""
-
-    def __init__(self) -> None:
-        self._lock = Lock()
-        self._current: Optional[LocalModel] = None
-
-    @property
-    def current_path(self) -> Optional[str]:
-        return self._current.path if self._current else None
-
-    def _load_model(self, model_path: Path) -> "Llama":
-        if Llama is None:
-            raise RuntimeError(
-                "llama-cpp-python is not installed. Install it to use local GGUF models."
-            )
-        kwargs = {
-            "model_path": str(model_path),
-            "n_ctx": GGUF_DEFAULT_CONTEXT,
-        }
-        if GGUF_THREADS:
-            kwargs["n_threads"] = GGUF_THREADS
-        if GGUF_N_GPU_LAYERS_INT is not None:
-            kwargs["n_gpu_layers"] = GGUF_N_GPU_LAYERS_INT
-        return Llama(**kwargs)
-
-    def get_model(self, model_path: str) -> "Llama":
-        target = str(Path(model_path).expanduser().resolve())
-        with self._lock:
-            if self._current and self._current.path == target:
-                return self._current.llama
-            llama = self._load_model(Path(target))
-            self._current = LocalModel(path=target, llama=llama)
-            return llama
-
-    def generate(self, request: GenerateRequest, messages: List[Dict[str, str]]) -> Dict[str, str]:
-        llama = self.get_model(request.gguf_path or "")
-        options: Dict[str, float | int] = {}
-        if request.temperature is not None:
-            options["temperature"] = request.temperature
-        if request.top_p is not None:
-            options["top_p"] = request.top_p
-        if request.top_k is not None:
-            options["top_k"] = request.top_k
-        if request.repeat_penalty is not None:
-            options["repeat_penalty"] = request.repeat_penalty
-        if request.seed is not None:
-            options["seed"] = request.seed
-        if request.max_tokens is not None:
-            options["max_tokens"] = request.max_tokens
-        with self._lock:
-            result = llama.create_chat_completion(messages=messages, **options)
-        choices = result.get("choices", [])
-        if not choices:
-            raise RuntimeError("Empty response from local model")
-        message = choices[0].get("message", {})
-        content = message.get("content", "").strip()
-        if not content:
-            raise RuntimeError("Local model returned empty content")
-        return {
-            "backend": "local",
-            "model": self.current_path,
-            "content": content,
-        }
-
-
-local_models = LocalModelManager()
-app = FastAPI(title="Comfy Prompt Builder")
+app = FastAPI(title="Prompt Creator")
 
 app.add_middleware(
     CORSMiddleware,
@@ -189,60 +55,58 @@ app.add_middleware(
 app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
 
 
-def _build_messages(request: GenerateRequest) -> List[Dict[str, str]]:
-    system_msg = request.system.strip() if request.system else DEFAULT_SYSTEM_PROMPT
-    if request.examples:
-        examples = request.examples.strip()
-        if examples:
-            system_msg += "\n\nFew-shot examples for style and format:\n" + examples
-    idea = request.idea.strip()
-    if not idea:
-        raise HTTPException(status_code=400, detail="Idea cannot be empty")
-    return [
-        {"role": "system", "content": system_msg},
-        {"role": "user", "content": idea},
-    ]
-
-
-def _get_roots() -> List[Path]:
-    roots: List[Path] = []
-    if GGUF_ENV_PATHS:
-        for raw in GGUF_ENV_PATHS.split(os.pathsep):
-            p = Path(raw).expanduser()
-            if p.exists():
-                roots.append(p)
-    if not roots:
-        home = Path.home()
-        roots.append(home)
-        if os.name != "nt":
-            roots.append(Path("/"))
-        else:
-            for letter in string.ascii_uppercase:
-                drive = Path(f"{letter}:\\")
-                if drive.exists():
-                    roots.append(drive)
-    seen = set()
-    unique_roots = []
-    for root in roots:
-        resolved = root.resolve()
-        if resolved in seen:
-            continue
-        unique_roots.append(resolved)
-        seen.add(resolved)
-    return unique_roots
-
-
 def _normalise_base_url(raw: Optional[str]) -> str:
-    base = (raw or "").strip() or KOBOLD_HOST
+    base = (raw or "").strip() or DEFAULT_KOBOLD_HOST
     parsed = urlparse(base)
     if not parsed.scheme:
         base = f"http://{base}"
     return base.rstrip("/")
 
 
+def _format_prompt(idea: str) -> str:
+    clean_idea = idea.strip()
+    if not clean_idea:
+        raise HTTPException(status_code=400, detail="Idea cannot be empty")
+    user_message = f"Create a new prompt from this idea: {clean_idea}"
+    sections = [
+        f"System:\n{SYSTEM_PROMPT}",
+        f"User:\n{user_message}",
+        "Assistant:\n",
+    ]
+    return "\n\n".join(sections)
+
+
+def _call_kobold(base: str, idea: str) -> Dict[str, Optional[str]]:
+    payload = {
+        "prompt": _format_prompt(idea),
+        "max_length": 600,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "stream": False,
+        "stop_sequence": ["\nUser:", "\nSystem:"],
+    }
+    try:
+        response = requests.post(
+            f"{base}/api/v1/generate", json=payload, timeout=(10, 180)
+        )
+        response.raise_for_status()
+    except Exception as exc:  # pragma: no cover - depends on external service
+        raise HTTPException(status_code=502, detail=f"Kobold connection failed: {exc}")
+    data = response.json()
+    results = data.get("results")
+    if not results:
+        raise HTTPException(status_code=502, detail="Kobold returned no content")
+    text = (results[0] or {}).get("text", "").strip()
+    if text.lower().startswith("assistant:"):
+        text = text.split(":", 1)[1].strip()
+    if not text:
+        raise HTTPException(status_code=502, detail="Kobold response was empty")
+    return {"content": text, "model": data.get("model")}
+
+
 @app.get("/api/kobold/status")
 def kobold_status(
-    url: Optional[str] = Query(default=None, description="Base URL of KoboldCpp server")
+    url: Optional[str] = Query(default=None, description="Base URL of Kobold server")
 ) -> Dict[str, Optional[str] | bool]:
     base = _normalise_base_url(url)
     result: Dict[str, Optional[str] | bool] = {"url": base, "online": False, "model": None}
@@ -263,126 +127,10 @@ def kobold_status(
     return result
 
 
-@app.get("/api/local/status")
-def local_status() -> Dict[str, Optional[str] | bool]:
-    available = Llama is not None
-    return {
-        "available": available,
-        "current_path": local_models.current_path if available else None,
-        "context": GGUF_DEFAULT_CONTEXT,
-        "threads": GGUF_THREADS,
-        "n_gpu_layers": GGUF_N_GPU_LAYERS_INT,
-        "implementation": platform.platform(),
-    }
-
-
-@app.get("/api/filetree", response_model=DirectoryListing)
-def browse_filetree(path: Optional[str] = Query(default=None, description="Directory to list")) -> DirectoryListing:
-    if path:
-        target = Path(path).expanduser()
-        if not target.exists():
-            raise HTTPException(status_code=404, detail="Path not found")
-        target = target.resolve()
-        if not target.is_dir():
-            raise HTTPException(status_code=400, detail="Path must be a directory")
-        directories: List[Dict[str, str]] = []
-        files: List[Dict[str, str]] = []
-        try:
-            for entry in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
-                if entry.is_dir():
-                    directories.append({"name": entry.name, "path": str(entry.resolve())})
-                elif entry.is_file() and entry.suffix.lower() == ".gguf":
-                    files.append({"name": entry.name, "path": str(entry.resolve())})
-        except PermissionError as exc:
-            raise HTTPException(status_code=403, detail=f"Permission denied: {exc}")
-        parent = str(target.parent) if target.parent != target else None
-        return DirectoryListing(
-            path=str(target),
-            parent=parent,
-            directories=directories,
-            files=files,
-        )
-    roots = [
-        {"name": str(root), "path": str(root)}
-        for root in _get_roots()
-    ]
-    return DirectoryListing(path=None, parent=None, directories=roots, files=[])
-
-
-def _format_messages_for_kobold(messages: List[Dict[str, str]]) -> str:
-    system_parts: List[str] = []
-    user_parts: List[str] = []
-    assistant_parts: List[str] = []
-    for message in messages:
-        role = message.get("role", "").lower()
-        content = message.get("content", "").strip()
-        if not content:
-            continue
-        if role == "system":
-            system_parts.append(content)
-        elif role == "assistant":
-            assistant_parts.append(content)
-        else:
-            user_parts.append(content)
-    sections = []
-    if system_parts:
-        sections.append("System:\n" + "\n\n".join(system_parts))
-    if user_parts:
-        sections.append("User:\n" + "\n\n".join(user_parts))
-    if assistant_parts:
-        sections.append("Assistant:\n" + "\n\n".join(assistant_parts))
-    sections.append("Assistant:\n")
-    return "\n\n".join(sections)
-
-
-def _call_kobold(request: GenerateRequest, messages: List[Dict[str, str]]) -> Dict[str, str]:
-    base = _normalise_base_url(request.kobold_url)
-    prompt = _format_messages_for_kobold(messages)
-    payload: Dict[str, object] = {
-        "prompt": prompt,
-        "max_length": request.max_tokens or 600,
-        "temperature": request.temperature if request.temperature is not None else 0.6,
-        "top_p": request.top_p if request.top_p is not None else 0.9,
-        "stream": False,
-        "stop_sequence": ["\nUser:", "\nSystem:"],
-    }
-    if request.top_k is not None:
-        payload["top_k"] = request.top_k
-    if request.repeat_penalty is not None:
-        payload["repetition_penalty"] = request.repeat_penalty
-    if request.seed is not None:
-        payload["seed"] = request.seed
-    try:
-        response = requests.post(
-            f"{base}/api/v1/generate", json=payload, timeout=(10, 180)
-        )
-        response.raise_for_status()
-        data = response.json()
-        results = data.get("results")
-        if not results:
-            raise RuntimeError("Empty response from KoboldCpp")
-        text = results[0].get("text", "")
-        content = text.strip()
-        if content.lower().startswith("assistant:"):
-            content = content.split(":", 1)[1].strip()
-        if not content:
-            raise RuntimeError("KoboldCpp returned empty content")
-        return {"backend": "koboldcpp", "model": data.get("model"), "content": content}
-    except HTTPException:
-        raise
-    except Exception as exc:  # pragma: no cover - depends on external service
-        raise HTTPException(status_code=502, detail=f"KoboldCpp error: {exc}")
-
-
 @app.post("/api/generate_prompt")
-def generate_prompt(request: GenerateRequest) -> Dict[str, str]:
-    backend = (request.backend or "koboldcpp").lower()
-    messages = _build_messages(request)
-    if backend == "local":
-        return local_models.generate(request, messages)
-    if backend in {"kobold", "koboldcpp"}:
-        return _call_kobold(request, messages)
-    raise HTTPException(status_code=400, detail=f"Unknown backend '{request.backend}'")
+def generate_prompt(request: GenerateRequest) -> Dict[str, Optional[str]]:
+    base = _normalise_base_url(request.kobold_url)
+    return _call_kobold(base, request.idea)
 
 
 __all__ = ["app"]

--- a/scripts/comfy_prompt_builder/static/app.js
+++ b/scripts/comfy_prompt_builder/static/app.js
@@ -1,262 +1,74 @@
-const $ = (selector) => document.querySelector(selector);
-const backendSelect = $('#backend');
-const koboldOptions = $('#koboldOptions');
-const localOptions = $('#localOptions');
-const koboldUrlInput = $('#koboldUrl');
-const koboldStatus = $('#koboldStatus');
-const localStatus = $('#localStatus');
-const ggufInput = $('#ggufPath');
-const generateBtn = $('#generate');
-const resultBox = $('#result');
-const copyPromptBtn = $('#copyPrompt');
-const browseBtn = $('#browse');
-const fileBrowser = $('#fileBrowser');
-const closeBrowserBtn = $('#closeBrowser');
-const entriesList = $('#entries');
-const breadcrumbs = $('#breadcrumbs');
-const entryTemplate = document.getElementById('entryTemplate');
+const statusMessage = document.getElementById('connectionStatus');
+const retryButton = document.getElementById('retryConnection');
+const ideaInput = document.getElementById('ideaInput');
+const sendButton = document.getElementById('sendIdea');
+const responseBox = document.getElementById('responseBox');
 
-const state = {
-  backend: 'koboldcpp',
-  browserPath: null,
-  lastResponse: null,
-};
+let koboldUrl = null;
 
-async function fetchJSON(url) {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(await res.text());
-  }
-  return res.json();
+function setStatus(message, isError = false) {
+  statusMessage.textContent = message;
+  statusMessage.classList.toggle('status__message--error', isError);
 }
 
-async function loadKoboldStatus() {
-  const base = koboldUrlInput.value.trim();
-  const query = base ? `?url=${encodeURIComponent(base)}` : '';
+async function checkConnection() {
+  setStatus('Checking Kobold connection…');
   try {
-    const data = await fetchJSON(`/api/kobold/status${query}`);
-    if (data.url && !base) {
-      koboldUrlInput.value = data.url;
+    const res = await fetch('/api/kobold/status');
+    if (!res.ok) {
+      throw new Error(await res.text());
     }
+    const data = await res.json();
+    koboldUrl = data.url || null;
     if (data.online) {
-      const label = data.model ? `Connected to ${data.model}` : 'Connected to KoboldCpp';
-      koboldStatus.textContent = label;
-      koboldStatus.classList.remove('error');
+      const label = data.model ? `Connected to ${data.model}` : 'Kobold connection established';
+      setStatus(label, false);
     } else if (data.error) {
-      koboldStatus.textContent = `Unable to reach KoboldCpp: ${data.error}`;
-      koboldStatus.classList.add('error');
+      setStatus(`Unable to reach Kobold: ${data.error}`, true);
     } else {
-      koboldStatus.textContent = 'KoboldCpp instance not detected yet.';
-      koboldStatus.classList.add('error');
+      setStatus('Kobold instance not detected yet.', true);
     }
   } catch (error) {
-    koboldStatus.textContent = `KoboldCpp unavailable: ${error.message}`;
-    koboldStatus.classList.add('error');
+    setStatus(`Connection check failed: ${error.message}`, true);
   }
 }
 
-async function loadLocalStatus() {
-  try {
-    const data = await fetchJSON('/api/local/status');
-    if (!data.available) {
-      localStatus.textContent = 'Install llama-cpp-python to enable local GGUF models.';
-      localStatus.classList.add('error');
-      return;
-    }
-    const details = [
-      data.current_path ? `Current: ${data.current_path}` : 'No model loaded yet',
-      `Context: ${data.context}`,
-    ];
-    if (data.threads) details.push(`Threads: ${data.threads}`);
-    if (data.n_gpu_layers !== null && data.n_gpu_layers !== undefined) {
-      details.push(`GPU layers: ${data.n_gpu_layers}`);
-    }
-    localStatus.textContent = details.join(' • ');
-    localStatus.classList.remove('error');
-  } catch (error) {
-    localStatus.textContent = `Local runtime unavailable: ${error.message}`;
-    localStatus.classList.add('error');
-  }
-}
-
-function switchBackend(value) {
-  state.backend = value;
-  if (value === 'koboldcpp') {
-    koboldOptions.classList.remove('hidden');
-    localOptions.classList.add('hidden');
-    loadKoboldStatus();
-  } else {
-    localOptions.classList.remove('hidden');
-    koboldOptions.classList.add('hidden');
-    loadLocalStatus();
-  }
-}
-
-function resetResult() {
-  resultBox.textContent = 'Generating…';
-}
-
-function renderResult(content) {
-  state.lastResponse = content;
-  resultBox.textContent = content;
-}
-
-async function generate() {
-  const idea = $('#idea').value.trim();
+async function sendIdea() {
+  const idea = ideaInput.value.trim();
   if (!idea) {
-    alert('Please provide an idea.');
+    setStatus('Please enter an idea before sending.', true);
+    ideaInput.focus();
     return;
   }
-  const payload = {
-    backend: state.backend,
-    idea,
-    system: $('#system').value,
-    examples: $('#examples').value,
-    temperature: parseFloat($('#temperature').value),
-    top_p: parseFloat($('#top_p').value),
-    top_k: $('#top_k').value ? parseInt($('#top_k').value, 10) : null,
-    repeat_penalty: $('#repeat_penalty').value ? parseFloat($('#repeat_penalty').value) : null,
-    seed: $('#seed').value ? parseInt($('#seed').value, 10) : null,
-    max_tokens: $('#max_tokens').value ? parseInt($('#max_tokens').value, 10) : null,
-  };
-  if (state.backend === 'koboldcpp') {
-    const url = koboldUrlInput.value.trim();
-    if (url) {
-      payload.kobold_url = url;
-    }
-  } else {
-    payload.gguf_path = ggufInput.value.trim();
-    if (!payload.gguf_path) {
-      alert('Select a GGUF file.');
-      return;
-    }
-  }
-  resetResult();
+
+  responseBox.textContent = 'Waiting for Kobold…';
   try {
     const res = await fetch('/api/generate_prompt', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ idea, kobold_url: koboldUrl }),
     });
     if (!res.ok) {
       const message = await res.text();
-      throw new Error(message);
+      throw new Error(message || 'Request failed');
     }
     const data = await res.json();
-    renderResult(data.content);
+    responseBox.textContent = data.content || 'Kobold returned no text.';
+    if (data.model) {
+      setStatus(`Connected to ${data.model}`, false);
+    }
   } catch (error) {
-    resultBox.textContent = `Error: ${error.message}`;
+    responseBox.textContent = `Error: ${error.message}`;
+    setStatus('Prompt request failed. Retry after checking Kobold.', true);
   }
 }
 
-function copyToClipboard(text) {
-  if (!text) return;
-  navigator.clipboard.writeText(text).catch(() => {
-    alert('Failed to copy to clipboard.');
-  });
-}
-
-function copyPrompt() {
-  if (state.lastResponse) {
-    copyToClipboard(state.lastResponse);
-  }
-}
-
-async function showBrowser(path = null) {
-  fileBrowser.classList.remove('hidden');
-  await loadDirectory(path);
-}
-
-function hideBrowser() {
-  fileBrowser.classList.add('hidden');
-}
-
-function renderBreadcrumbs(path) {
-  if (!path) {
-    breadcrumbs.textContent = 'Root';
-    return;
-  }
-  breadcrumbs.textContent = path;
-}
-
-function createEntry(item, type) {
-  const element = entryTemplate.content.firstElementChild.cloneNode(true);
-  const button = element.querySelector('button');
-  button.textContent = item.name;
-  if (type === 'dir') {
-    const span = document.createElement('span');
-    span.textContent = 'Open';
-    button.appendChild(span);
-    button.addEventListener('click', () => loadDirectory(item.path));
-  } else {
-    const span = document.createElement('span');
-    span.textContent = 'Use';
-    button.appendChild(span);
-    button.addEventListener('click', () => {
-      ggufInput.value = item.path;
-      hideBrowser();
-      loadLocalStatus();
-    });
-  }
-  return element;
-}
-
-async function loadDirectory(path = null) {
-  entriesList.innerHTML = '';
-  try {
-    const url = new URL('/api/filetree', window.location.origin);
-    if (path) {
-      url.searchParams.set('path', path);
-    }
-    const data = await fetchJSON(url);
-    state.browserPath = data.path;
-    renderBreadcrumbs(data.path);
-    if (data.parent) {
-      const parentEntry = createEntry({ name: '…', path: data.parent }, 'dir');
-      entriesList.appendChild(parentEntry);
-    }
-    data.directories.forEach((dir) => {
-      const dirEntry = createEntry(dir, 'dir');
-      entriesList.appendChild(dirEntry);
-    });
-    if (data.files.length === 0 && data.directories.length === 0) {
-      const empty = document.createElement('li');
-      empty.textContent = 'No entries';
-      entriesList.appendChild(empty);
-    }
-    data.files.forEach((file) => {
-      const fileEntry = createEntry(file, 'file');
-      entriesList.appendChild(fileEntry);
-    });
-  } catch (error) {
-    const item = document.createElement('li');
-    item.textContent = `Unable to list entries: ${error.message}`;
-    entriesList.appendChild(item);
-  }
-}
-
-backendSelect.addEventListener('change', (event) => {
-  switchBackend(event.target.value);
-});
-
-generateBtn.addEventListener('click', generate);
-copyPromptBtn.addEventListener('click', copyPrompt);
-browseBtn.addEventListener('click', () => showBrowser(state.browserPath));
-closeBrowserBtn.addEventListener('click', hideBrowser);
-fileBrowser.addEventListener('click', (event) => {
-  if (event.target === fileBrowser) {
-    hideBrowser();
+retryButton.addEventListener('click', checkConnection);
+sendButton.addEventListener('click', sendIdea);
+ideaInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+    sendIdea();
   }
 });
 
-koboldUrlInput.addEventListener('change', loadKoboldStatus);
-koboldUrlInput.addEventListener('blur', loadKoboldStatus);
-
-window.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && !fileBrowser.classList.contains('hidden')) {
-    hideBrowser();
-  }
-});
-
-switchBackend(backendSelect.value);
-loadKoboldStatus();
+checkConnection();

--- a/scripts/comfy_prompt_builder/static/index.html
+++ b/scripts/comfy_prompt_builder/static/index.html
@@ -3,179 +3,36 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Flux Prompt Builder</title>
+    <title>Prompt Creator</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="layout">
-      <header>
-        <h1>Flux Prompt Builder</h1>
-        <p>
-          Turn a quick idea into a fully-formed Flux prompt. This tool focuses
-          exclusively on the prompt text—no image parameters, no samplers, no
-          CFG values. Connect to a running KoboldCpp server or point directly to
-          a local <code>.gguf</code> model.
+    <main class="app">
+      <header class="app__header">
+        <h1>Prompt Creator</h1>
+        <p class="app__subtitle">
+          Enter an idea and let the connected Kobold service expand it into a rich text-to-image prompt.
         </p>
       </header>
 
-      <section class="panel">
-        <h2>Prompt format</h2>
-        <p class="hint">
-          The model expands every idea into four flowing sentences covering the
-          subject, scene/environment, style/medium, and technical modifiers.
-          Expect a single text string with descriptions only—never parameter
-          blocks or JSON.
-        </p>
-        <div class="examples-list">
-          <article>
-            <h3>Idea: flower. sunset</h3>
-            <p>
-              A single vivid wildflower standing tall in the foreground of a
-              golden meadow at dusk. The horizon glows with warm orange and
-              lavender clouds while distant hills fade into soft haze. Style:
-              cinematic photography with shallow depth of field and tactile
-              macro detail. Technical: golden hour glow, gentle lens flare,
-              creamy bokeh, ultra crisp textures, 8k clarity.
-            </p>
-          </article>
-          <article>
-            <h3>Idea: snowy mountain cabin</h3>
-            <p>
-              A hand-built log cabin with smoke curling from the chimney nestled
-              beside frost-laden pines. Moonlight reflects off untouched alpine
-              snowdrifts and a star-studded peak towering behind. Style:
-              hyperreal winter landscape photography with subtle film grain.
-              Technical: midnight blue palette, long exposure shimmer,
-              wide-angle composition, crystalline highlights, 8k definition.
-            </p>
-          </article>
-          <article>
-            <h3>Idea: retro-futuristic city skyline</h3>
-            <p>
-              A sweeping skyline of retro-futuristic skyscrapers crowned with
-              chrome spires and neon billboards. Elevated highways weave between
-              hovering transit pods above a sunset-lit harbor. Style: vibrant
-              digital illustration blending art deco and synthwave aesthetics.
-              Technical: magenta and cyan bloom lighting, atmospheric haze,
-              cinematic framing, ultra detailed reflections, 32mm lens
-              perspective.
-            </p>
-          </article>
-        </div>
+      <section class="status" aria-live="polite">
+        <div id="connectionStatus" class="status__message">Checking Kobold connection…</div>
+        <button id="retryConnection" type="button" class="button">Retry connection</button>
       </section>
 
-      <section class="panel">
-        <h2>Model Source</h2>
-        <div class="field">
-          <label for="backend">Backend</label>
-          <select id="backend">
-            <option value="koboldcpp">KoboldCpp server</option>
-            <option value="local">Local GGUF</option>
-          </select>
-        </div>
-
-        <div id="koboldOptions" class="field-group">
-          <label for="koboldUrl">KoboldCpp server URL</label>
-          <input id="koboldUrl" placeholder="http://127.0.0.1:5001" />
-          <p class="hint">
-            Leave empty to use the default address. Ensure KoboldCpp is running
-            with its API enabled.
-          </p>
-          <div id="koboldStatus" class="status"></div>
-        </div>
-
-        <div id="localOptions" class="field-group hidden">
-          <label for="ggufPath">GGUF path</label>
-          <div class="file-row">
-            <input id="ggufPath" placeholder="Select a .gguf model" />
-            <button id="browse" type="button">Browse…</button>
-          </div>
-          <div id="localStatus" class="status"></div>
-          <details class="hint">
-            <summary>Runtime options</summary>
-            <p>
-              Adjust with environment variables before launching:
-              <code>GGUF_CONTEXT</code>, <code>GGUF_THREADS</code>,
-              <code>GGUF_N_GPU_LAYERS</code>, <code>GGUF_SEARCH_PATHS</code>.
-            </p>
-          </details>
-        </div>
-      </section>
-
-      <section class="panel">
-        <h2>Prompt Controls</h2>
-        <div class="grid">
-          <label>
-            <span>Temperature</span>
-            <input id="temperature" type="number" step="0.05" value="0.6" />
-          </label>
-          <label>
-            <span>Top P</span>
-            <input id="top_p" type="number" step="0.05" value="0.9" />
-          </label>
-          <label>
-            <span>Top K</span>
-            <input id="top_k" type="number" step="1" placeholder="Default" />
-          </label>
-          <label>
-            <span>Repeat penalty</span>
-            <input id="repeat_penalty" type="number" step="0.05" placeholder="Default" />
-          </label>
-          <label>
-            <span>Seed</span>
-            <input id="seed" type="number" step="1" placeholder="Random" />
-          </label>
-          <label>
-            <span>Max tokens</span>
-            <input id="max_tokens" type="number" step="50" value="600" />
-          </label>
-        </div>
-
-        <label>
-          <span>Idea</span>
-          <input id="idea" placeholder="e.g., neon-lit rainy alley portrait" />
+      <section class="interaction">
+        <label class="field" for="ideaInput">
+          <span class="field__label">Idea</span>
+          <textarea id="ideaInput" class="field__control" rows="5" placeholder="Describe your concept"></textarea>
         </label>
-
-        <label>
-          <span>System prompt</span>
-          <textarea id="system" rows="5" placeholder="Leave empty to use the built-in template"></textarea>
-        </label>
-
-        <label>
-          <span>Few-shot examples</span>
-          <textarea id="examples" rows="5" placeholder="Paste optional examples to steer formatting"></textarea>
-        </label>
-
-        <button id="generate" type="button" class="primary">Generate prompt</button>
+        <button id="sendIdea" type="button" class="button button--primary">Send to Kobold</button>
       </section>
 
-      <section class="panel">
-        <h2>Result</h2>
-        <div id="result" class="result">No generation yet.</div>
-        <div class="actions">
-          <button id="copyPrompt" type="button">Copy prompt</button>
-        </div>
+      <section class="output" aria-live="polite">
+        <span class="field__label">Response</span>
+        <pre id="responseBox" class="output__box">No response yet.</pre>
       </section>
-    </div>
-
-    <div id="fileBrowser" class="modal hidden">
-      <div class="modal-dialog">
-        <header>
-          <h2>Select GGUF</h2>
-          <button id="closeBrowser" type="button">×</button>
-        </header>
-        <div class="modal-body">
-          <div class="breadcrumbs" id="breadcrumbs"></div>
-          <ul id="entries" class="entries"></ul>
-        </div>
-      </div>
-    </div>
-
-    <template id="entryTemplate">
-      <li>
-        <button type="button"></button>
-      </li>
-    </template>
+    </main>
 
     <script src="app.js"></script>
   </body>

--- a/scripts/comfy_prompt_builder/static/styles.css
+++ b/scripts/comfy_prompt_builder/static/styles.css
@@ -5,258 +5,172 @@
   color: #f3f4f6;
 }
 
-body {
-  margin: 0;
-  padding: 24px;
-  background: linear-gradient(180deg, rgba(15, 17, 21, 1) 0%, rgba(23, 26, 33, 1) 100%);
+* {
+  box-sizing: border-box;
 }
 
-h1,
- h2,
- h3 {
-  margin: 0 0 12px;
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: radial-gradient(circle at top, rgba(50, 86, 255, 0.25), transparent 55%),
+    radial-gradient(circle at bottom, rgba(42, 198, 255, 0.2), transparent 45%),
+    #0b0d12;
+}
+
+.app {
+  width: min(720px, 100%);
+  display: grid;
+  gap: 24px;
+  background: rgba(20, 24, 33, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.8);
+}
+
+.app__header {
+  display: grid;
+  gap: 8px;
+}
+
+.app__header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
   font-weight: 600;
 }
 
-p {
-  margin: 0 0 12px;
+.app__subtitle {
+  margin: 0;
+  color: #c7cad8;
+  font-size: 1rem;
 }
 
-.layout {
-  max-width: 1100px;
-  margin: 0 auto;
+.status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(26, 31, 43, 0.75);
+}
+
+.status__message {
+  flex: 1 1 auto;
+  font-size: 0.95rem;
+  color: #8eb5ff;
+}
+
+.status__message.status__message--error {
+  color: #ff8da1;
+}
+
+.interaction {
   display: grid;
   gap: 16px;
 }
 
-header p {
-  color: #c7cad5;
+.field {
+  display: grid;
+  gap: 8px;
 }
 
-.panel {
-  background: rgba(32, 36, 44, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 16px;
-  padding: 20px;
-  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.6);
+.field__label {
+  font-size: 0.95rem;
+  color: #c7cad8;
 }
 
-.field,
-.field-group,
-label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 16px;
-}
-
-input,
-textarea,
-select,
-button {
+.field__control {
   font: inherit;
-}
-
-input,
-textarea,
-select {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(17, 19, 24, 0.8);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 15, 22, 0.9);
   color: inherit;
-  border-radius: 10px;
-  padding: 10px 12px;
-}
-
-textarea {
+  padding: 12px 14px;
   resize: vertical;
-  min-height: 120px;
+  min-height: 140px;
+  transition: border-color 0.2s ease;
 }
 
-button {
+.field__control:focus {
+  outline: none;
+  border-color: rgba(130, 180, 255, 0.8);
+  box-shadow: 0 0 0 3px rgba(98, 142, 255, 0.2);
+}
+
+.button {
+  font: inherit;
   border: none;
-  border-radius: 10px;
-  background: rgba(61, 143, 255, 0.12);
-  color: #7fb7ff;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 12px 22px;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  background: rgba(98, 142, 255, 0.18);
+  color: #9fc1ff;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
 }
 
-button:hover {
-  background: rgba(61, 143, 255, 0.2);
-  color: #a7ceff;
+.button:hover,
+.button:focus-visible {
+  background: rgba(98, 142, 255, 0.28);
+  color: #c5d8ff;
 }
 
-button.primary {
-  background: linear-gradient(135deg, #619bff, #5f5fff);
-  color: white;
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(114, 178, 255, 0.35);
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #7b5cff, #4da6ff);
+  color: #ffffff;
   font-weight: 600;
 }
 
-button.primary:hover {
-  background: linear-gradient(135deg, #7bb0ff, #7373ff);
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: linear-gradient(135deg, #8e6bff, #61b6ff);
+  color: #ffffff;
 }
 
-.file-row {
-  display: flex;
-  gap: 8px;
-}
-
-.file-row input {
-  flex: 1;
-}
-
-.grid {
+.output {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 
-.result {
-  min-height: 160px;
-  background: rgba(12, 14, 18, 0.9);
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 12px;
-  white-space: pre-wrap;
+.output__box {
+  margin: 0;
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
-}
-
-.actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.examples-list {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  margin-top: 12px;
-}
-
-.examples-list article {
-  background: rgba(15, 18, 24, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(12, 16, 24, 0.95);
   padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  min-height: 160px;
+  white-space: pre-wrap;
+  line-height: 1.6;
+  color: #e5e9f5;
 }
 
-.examples-list h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: #9fc7ff;
-}
+@media (max-width: 540px) {
+  .app {
+    padding: 24px;
+    gap: 20px;
+  }
 
-.examples-list p {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #d5d9e5;
-  line-height: 1.55;
-}
+  .status {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.hint {
-  font-size: 0.9rem;
-  color: #9aa0b3;
-}
-
-.status {
-  min-height: 20px;
-  font-size: 0.9rem;
-  color: #9fc7ff;
-}
-
-.status.error {
-  color: #ff7f9f;
-}
-
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.65);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.modal.hidden {
-  display: none;
-}
-
-.modal-dialog {
-  background: rgba(24, 27, 34, 0.95);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  width: min(760px, 90vw);
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-dialog header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.modal-dialog header h2 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.modal-dialog header button {
-  background: transparent;
-  font-size: 1.4rem;
-  color: inherit;
-  padding: 4px 10px;
-}
-
-.modal-body {
-  padding: 14px 20px 20px;
-  overflow: auto;
-}
-
-.breadcrumbs {
-  font-size: 0.9rem;
-  margin-bottom: 12px;
-  color: #a0a4b6;
-  word-break: break-all;
-}
-
-.entries {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 6px;
-}
-
-.entries li button {
-  width: 100%;
-  text-align: left;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: rgba(17, 19, 24, 0.9);
-}
-
-.entries li button span {
-  opacity: 0.7;
-  font-size: 0.85rem;
-}
-
-.hidden {
-  display: none !important;
-}
-
-@media (max-width: 720px) {
-  body {
-    padding: 16px;
+  .button {
+    width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- replace the prompt creator UI with a minimal page that checks the Kobold connection, retries on demand, and exposes a single idea field with a response area
- streamline the FastAPI backend to always pair the system prompt with the required user instruction and call Kobold for generations without any parameter references
- refresh the bundled system prompt text to focus on descriptive guidance only

## Testing
- `python -m compileall scripts/comfy_prompt_builder/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68cda8ba5d00832493db42f1e026449f