### PR TITLE
Simplify prompt creator UI and improve Kobold detection

### DIFF
--- a/scripts/comfy_prompt_builder/server.py
+++ b/scripts/comfy_prompt_builder/server.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -19,7 +20,24 @@ SYSTEM_PROMPT_PATH = Path(
     os.getenv("COMFY_SYSTEM_PROMPT")
     or BASE_DIR / "comfy_diffusion_image_prompt.txt"
 )
-DEFAULT_KOBOLD_HOST = os.getenv("KOBOLD_HOST", "http://127.0.0.1:5001").rstrip("/")
+
+
+def _coerce_base(raw: Optional[str]) -> Optional[str]:
+    if raw is None:
+        return None
+    base = raw.strip()
+    if not base:
+        return None
+    parsed = urlparse(base)
+    if not parsed.scheme:
+        base = f"http://{base}"
+    return base.rstrip("/")
+
+
+DEFAULT_KOBOLD_HOST = (
+    _coerce_base(os.getenv("KOBOLD_HOST") or "http://127.0.0.1:5001")
+    or "http://127.0.0.1:5001"
+)
 
 
 def _load_system_prompt() -> str:
@@ -52,22 +70,35 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
-def _normalise_base_url(raw: Optional[str]) -> str:
-    base = (raw or "").strip() or DEFAULT_KOBOLD_HOST
-    parsed = urlparse(base)
-    if not parsed.scheme:
-        base = f"http://{base}"
-    return base.rstrip("/")
+@app.get("/", response_class=FileResponse)
+def root() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+def _candidate_bases(preferred: Optional[str]) -> Iterable[str]:
+    raw_candidates = [
+        preferred,
+        DEFAULT_KOBOLD_HOST,
+        "http://127.0.0.1:5001",
+        "http://localhost:5001",
+        "http://0.0.0.0:5001",
+    ]
+    seen = set()
+    for raw in raw_candidates:
+        base = _coerce_base(raw)
+        if base and base not in seen:
+            seen.add(base)
+            yield base
 
 
 def _format_prompt(idea: str) -> str:
     clean_idea = idea.strip()
     if not clean_idea:
         raise HTTPException(status_code=400, detail="Idea cannot be empty")
-    user_message = f"Create a new prompt from this idea: {clean_idea}"
+    user_message = f"Create a new prompt from this idea:{clean_idea}"
     sections = [
         f"System:\n{SYSTEM_PROMPT}",
         f"User:\n{user_message}",
@@ -76,61 +107,113 @@ def _format_prompt(idea: str) -> str:
     return "\n\n".join(sections)
 
 
+def _extract_model_name(data: Dict[str, object]) -> Optional[str]:
+    if not isinstance(data, dict):
+        return None
+    direct_keys = ("model", "model_name", "name")
+    for key in direct_keys:
+        value = data.get(key)
+        if value:
+            return str(value)
+    nested = data.get("result")
+    if isinstance(nested, dict):
+        for key in direct_keys:
+            value = nested.get(key)
+            if value:
+                return str(value)
+    return None
+
+
+def _probe_model(base: str) -> Tuple[bool, Optional[str], Optional[str]]:
+    endpoints = [
+        "/api/v1/model",
+        "/api/model",
+        "/v1/model",
+        "/api/v1/status",
+    ]
+    errors = []
+    for path in endpoints:
+        url = f"{base}{path}"
+        try:
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+            data = response.json()
+            model_name = _extract_model_name(data)
+            return True, model_name, None
+        except Exception as exc:  # pragma: no cover - depends on external service
+            errors.append(f"{url}: {exc}")
+    return False, None, "; ".join(errors) if errors else None
+
+
 def _call_kobold(base: str, idea: str) -> Dict[str, Optional[str]]:
-    payload = {
-        "prompt": _format_prompt(idea),
-        "max_length": 600,
-        "temperature": 0.7,
-        "top_p": 0.9,
-        "stream": False,
-        "stop_sequence": ["\nUser:", "\nSystem:"],
-    }
-    try:
-        response = requests.post(
-            f"{base}/api/v1/generate", json=payload, timeout=(10, 180)
-        )
-        response.raise_for_status()
-    except Exception as exc:  # pragma: no cover - depends on external service
-        raise HTTPException(status_code=502, detail=f"Kobold connection failed: {exc}")
-    data = response.json()
-    results = data.get("results")
-    if not results:
-        raise HTTPException(status_code=502, detail="Kobold returned no content")
-    text = (results[0] or {}).get("text", "").strip()
-    if text.lower().startswith("assistant:"):
-        text = text.split(":", 1)[1].strip()
-    if not text:
-        raise HTTPException(status_code=502, detail="Kobold response was empty")
-    return {"content": text, "model": data.get("model")}
+    payload = {"prompt": _format_prompt(idea)}
+    endpoints = [
+        f"{base}/api/v1/generate",
+        f"{base}/api/generate",
+        f"{base}/v1/generate",
+    ]
+    errors = []
+    for url in endpoints:
+        try:
+            response = requests.post(url, json=payload, timeout=(10, 180))
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - depends on external service
+            errors.append(f"{url}: {exc}")
+            continue
+        data = response.json()
+        text: Optional[str] = None
+        results = data.get("results")
+        if isinstance(results, list) and results:
+            first = results[0] or {}
+            if isinstance(first, dict):
+                text = str(first.get("text", "")).strip()
+        elif "text" in data:
+            candidate = data.get("text")
+            if isinstance(candidate, str):
+                text = candidate.strip()
+        if text and text.lower().startswith("assistant:"):
+            text = text.split(":", 1)[1].strip()
+        if text:
+            return {"content": text, "model": _extract_model_name(data)}
+        errors.append(f"{url}: Kobold response was empty")
+    raise HTTPException(
+        status_code=502,
+        detail="; ".join(errors) if errors else "Kobold response was empty",
+    )
 
 
 @app.get("/api/kobold/status")
 def kobold_status(
     url: Optional[str] = Query(default=None, description="Base URL of Kobold server")
 ) -> Dict[str, Optional[str] | bool]:
-    base = _normalise_base_url(url)
-    result: Dict[str, Optional[str] | bool] = {"url": base, "online": False, "model": None}
-    try:
-        response = requests.get(f"{base}/api/v1/model", timeout=5)
-        response.raise_for_status()
-        data = response.json()
-        model_name = (
-            data.get("result")
-            or data.get("model")
-            or data.get("name")
-            or data.get("model_name")
-        )
-        result["online"] = True
-        result["model"] = model_name
-    except Exception as exc:  # pragma: no cover - depends on external service
-        result["error"] = str(exc)
+    candidates = list(_candidate_bases(url))
+    result: Dict[str, Optional[str] | bool] = {
+        "url": candidates[0] if candidates else None,
+        "online": False,
+        "model": None,
+    }
+    errors = []
+    for base in candidates:
+        ok, model_name, error = _probe_model(base)
+        if ok:
+            result.update({"url": base, "online": True, "model": model_name})
+            return result
+        if error:
+            errors.append(error)
+    if errors:
+        result["error"] = "; ".join(errors)
     return result
 
 
 @app.post("/api/generate_prompt")
 def generate_prompt(request: GenerateRequest) -> Dict[str, Optional[str]]:
-    base = _normalise_base_url(request.kobold_url)
-    return _call_kobold(base, request.idea)
+    errors = []
+    for base in _candidate_bases(request.kobold_url):
+        try:
+            return _call_kobold(base, request.idea)
+        except HTTPException as exc:
+            errors.append(f"{base}: {exc.detail}")
+    raise HTTPException(status_code=502, detail="; ".join(errors))
 
 
 __all__ = ["app"]

--- a/scripts/comfy_prompt_builder/static/index.html
+++ b/scripts/comfy_prompt_builder/static/index.html
@@ -4,36 +4,38 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Prompt Creator</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
     <main class="app">
-      <header class="app__header">
-        <h1>Prompt Creator</h1>
-        <p class="app__subtitle">
-          Enter an idea and let the connected Kobold service expand it into a rich text-to-image prompt.
-        </p>
-      </header>
+      <h1 class="app__title">Prompt Creator</h1>
+      <p class="app__intro">
+        Type your idea, send it, and read the response that Kobold generates from the shared system prompt.
+      </p>
 
       <section class="status" aria-live="polite">
-        <div id="connectionStatus" class="status__message">Checking Kobold connection…</div>
-        <button id="retryConnection" type="button" class="button">Retry connection</button>
+        <p id="connectionStatus" class="status__message">Checking Kobold connection…</p>
+        <button id="retryConnection" type="button" class="button">Try again</button>
       </section>
 
-      <section class="interaction">
-        <label class="field" for="ideaInput">
-          <span class="field__label">Idea</span>
-          <textarea id="ideaInput" class="field__control" rows="5" placeholder="Describe your concept"></textarea>
-        </label>
-        <button id="sendIdea" type="button" class="button button--primary">Send to Kobold</button>
-      </section>
+      <label class="field" for="ideaInput">
+        <span class="field__label">Idea</span>
+        <textarea
+          id="ideaInput"
+          class="field__control"
+          rows="4"
+          placeholder="Describe what you would like the prompt to cover"
+        ></textarea>
+      </label>
 
-      <section class="output" aria-live="polite">
+      <button id="sendIdea" type="button" class="button button--primary">Send</button>
+
+      <label class="field" for="responseBox">
         <span class="field__label">Response</span>
-        <pre id="responseBox" class="output__box">No response yet.</pre>
-      </section>
+        <textarea id="responseBox" class="field__control field__control--output" rows="8" readonly>No response yet.</textarea>
+      </label>
     </main>
 
-    <script src="app.js"></script>
+    <script src="/static/app.js"></script>
   </body>
 </html>

--- a/scripts/comfy_prompt_builder/static/styles.css
+++ b/scripts/comfy_prompt_builder/static/styles.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: dark;
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-  background: #0f1115;
-  color: #f3f4f6;
+  background-color: #0f1116;
+  color: #f5f7ff;
 }
 
 * {
@@ -15,91 +15,88 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px 16px;
-  background: radial-gradient(circle at top, rgba(50, 86, 255, 0.25), transparent 55%),
-    radial-gradient(circle at bottom, rgba(42, 198, 255, 0.2), transparent 45%),
-    #0b0d12;
+  padding: 24px;
+  background: radial-gradient(circle at top, rgba(112, 134, 255, 0.2), transparent 55%),
+    radial-gradient(circle at bottom, rgba(63, 194, 255, 0.18), transparent 45%),
+    #0a0c12;
 }
 
 .app {
-  width: min(720px, 100%);
+  width: min(520px, 100%);
   display: grid;
-  gap: 24px;
-  background: rgba(20, 24, 33, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 20px;
-  padding: 32px;
-  box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.8);
+  gap: 18px;
+  padding: 28px;
+  background: rgba(16, 19, 29, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 18px;
+  box-shadow: 0 28px 70px -40px rgba(8, 12, 24, 0.9);
 }
 
-.app__header {
-  display: grid;
-  gap: 8px;
-}
-
-.app__header h1 {
+.app__title {
   margin: 0;
-  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
   font-weight: 600;
 }
 
-.app__subtitle {
+.app__intro {
   margin: 0;
-  color: #c7cad8;
-  font-size: 1rem;
+  color: #c9ccda;
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 
 .status {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  padding: 16px;
+  gap: 10px;
+  padding: 14px;
   border-radius: 14px;
-  background: rgba(26, 31, 43, 0.75);
+  background: rgba(22, 27, 39, 0.9);
 }
 
 .status__message {
   flex: 1 1 auto;
-  font-size: 0.95rem;
-  color: #8eb5ff;
+  margin: 0;
+  font-size: 0.9rem;
+  color: #96b8ff;
 }
 
 .status__message.status__message--error {
-  color: #ff8da1;
-}
-
-.interaction {
-  display: grid;
-  gap: 16px;
+  color: #ff9fb1;
 }
 
 .field {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .field__label {
-  font-size: 0.95rem;
-  color: #c7cad8;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  color: #cfd3e5;
 }
 
 .field__control {
   font: inherit;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 15, 22, 0.9);
+  background: rgba(10, 13, 21, 0.95);
   color: inherit;
   padding: 12px 14px;
   resize: vertical;
-  min-height: 140px;
-  transition: border-color 0.2s ease;
+  min-height: 120px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .field__control:focus {
   outline: none;
-  border-color: rgba(130, 180, 255, 0.8);
-  box-shadow: 0 0 0 3px rgba(98, 142, 255, 0.2);
+  border-color: rgba(132, 176, 255, 0.85);
+  box-shadow: 0 0 0 3px rgba(104, 150, 255, 0.2);
+}
+
+.field__control--output {
+  min-height: 180px;
+  white-space: pre-wrap;
 }
 
 .button {
@@ -108,20 +105,20 @@ body {
   border-radius: 999px;
   padding: 12px 22px;
   cursor: pointer;
-  background: rgba(98, 142, 255, 0.18);
-  color: #9fc1ff;
+  background: rgba(108, 142, 255, 0.18);
+  color: #a9c5ff;
   transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
 }
 
 .button:hover,
 .button:focus-visible {
-  background: rgba(98, 142, 255, 0.28);
-  color: #c5d8ff;
+  background: rgba(108, 142, 255, 0.3);
+  color: #d0dcff;
 }
 
 .button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(114, 178, 255, 0.35);
+  box-shadow: 0 0 0 3px rgba(108, 142, 255, 0.3);
 }
 
 .button:active {
@@ -129,39 +126,25 @@ body {
 }
 
 .button--primary {
-  background: linear-gradient(135deg, #7b5cff, #4da6ff);
+  background: linear-gradient(135deg, #7d5cff, #55a8ff);
   color: #ffffff;
   font-weight: 600;
 }
 
 .button--primary:hover,
 .button--primary:focus-visible {
-  background: linear-gradient(135deg, #8e6bff, #61b6ff);
+  background: linear-gradient(135deg, #8a68ff, #63b5ff);
   color: #ffffff;
 }
 
-.output {
-  display: grid;
-  gap: 10px;
-}
-
-.output__box {
-  margin: 0;
-  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  background: rgba(12, 16, 24, 0.95);
-  padding: 16px;
-  min-height: 160px;
-  white-space: pre-wrap;
-  line-height: 1.6;
-  color: #e5e9f5;
-}
-
 @media (max-width: 540px) {
+  body {
+    padding: 16px;
+  }
+
   .app {
-    padding: 24px;
-    gap: 20px;
+    padding: 22px;
+    gap: 16px;
   }
 
   .status {
@@ -171,6 +154,5 @@ body {
 
   .button {
     width: 100%;
-    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the prompt creator interface down to a single idea input, send button, and response display
- rework the connection logic to try several Kobold hosts and endpoints with fallbacks for reliability
- streamline Kobold prompt generation to use only the system prompt file plus the formatted idea text

## Testing
- python -m compileall scripts/comfy_prompt_builder/server.py

------
https://chatgpt.com/codex/tasks/task_e_68cdab6bb8bc83248dc02706bb3e94f5