### PR TITLE
Add Kobold opener button with Prompter preset

### DIFF
--- a/scripts/comfy_prompt_builder/static/index.html
+++ b/scripts/comfy_prompt_builder/static/index.html
@@ -16,6 +16,7 @@
       <section class="status" aria-live="polite">
         <p id="connectionStatus" class="status__message">Checking Kobold connection…</p>
         <button id="retryConnection" type="button" class="button">Try again</button>
+        <button id="openKobold" type="button" class="button">Open Kobold (Prompter preset)</button>
       </section>
 
       <label class="field" for="ideaInput">

--- a/scripts/comfy_prompt_builder/static/styles.css
+++ b/scripts/comfy_prompt_builder/static/styles.css
@@ -125,10 +125,24 @@ body {
   transform: translateY(1px);
 }
 
+.button:disabled,
+.button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  background: rgba(108, 142, 255, 0.12);
+  color: #7f8db8;
+}
+
 .button--primary {
   background: linear-gradient(135deg, #7d5cff, #55a8ff);
   color: #ffffff;
   font-weight: 600;
+}
+
+.button--primary:disabled,
+.button--primary[aria-disabled='true'] {
+  background: linear-gradient(135deg, rgba(125, 92, 255, 0.5), rgba(85, 168, 255, 0.5));
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .button--primary:hover,


### PR DESCRIPTION
## Summary
- add an "Open Kobold" control to the prompt builder status area that opens the Prompter preset
- manage the new button state based on connection availability and improve status messaging
- style disabled buttons so the new control communicates availability

## Testing
- manual verification: launched the prompt builder server

------
https://chatgpt.com/codex/tasks/task_e_68cdbaed0c308324a3dee5e67dad1c1f