### PR TITLE
Add parallel passive-capture jobs with progress UI and stronger stream fallbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,10 @@ import os
 import shlex
 import subprocess
 import sys
+import threading
+import uuid
 from pathlib import Path
+from datetime import datetime, timezone
 from typing import Dict, List, Tuple
 
 from flask import Flask, flash, jsonify, redirect, render_template, request, url_for
@@ -21,11 +24,18 @@ LYRICS_CONFIG = SCRIPTS_DIR / 'lyrics_embedder_config.json'
 MEDIA_HARVESTER_SCRIPT = SCRIPTS_DIR / 'media_harvester.py'
 MEDIA_PASSIVE_CAPTURE_SCRIPT = SCRIPTS_DIR / 'media_passive_capture.py'
 MEDIA_HARVESTER_DEFAULTS = SCRIPTS_DIR / 'media_harvester_defaults.json'
+PASSIVE_CAPTURE_JOBS: Dict[str, Dict[str, object]] = {}
+PASSIVE_CAPTURE_LOCK = threading.Lock()
 
 try:
     from openai import OpenAI
 except Exception:  # pragma: no cover - optional runtime dependency
     OpenAI = None  # type: ignore
+
+try:
+    from scripts import media_passive_capture as passive_capture_module
+except Exception:  # pragma: no cover - import optional during partial installs
+    passive_capture_module = None  # type: ignore
 
 
 
@@ -72,6 +82,105 @@ def coerce_media_harvester_values(values):
         values['all_page'] = '1'
 
     return values
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _create_passive_job(payload: Dict[str, object]) -> str:
+    job_id = uuid.uuid4().hex[:12]
+    job = {
+        'id': job_id,
+        'status': 'queued',
+        'progress': 0,
+        'step': 'Queued',
+        'created_at': _iso_now(),
+        'updated_at': _iso_now(),
+        'config': payload,
+        'logs': [],
+        'result': {'success': 0, 'failed': 0},
+    }
+    with PASSIVE_CAPTURE_LOCK:
+        PASSIVE_CAPTURE_JOBS[job_id] = job
+    return job_id
+
+
+def _append_job_log(job: Dict[str, object], line: str) -> None:
+    logs = job.get('logs')
+    if isinstance(logs, list):
+        logs.append(line)
+        if len(logs) > 300:
+            del logs[:-300]
+
+
+def _run_passive_capture_job(job_id: str) -> None:
+    with PASSIVE_CAPTURE_LOCK:
+        job = PASSIVE_CAPTURE_JOBS.get(job_id)
+    if not job:
+        return
+    if passive_capture_module is None:
+        job['status'] = 'failed'
+        job['step'] = 'Module import error'
+        job['progress'] = 100
+        _append_job_log(job, 'Passive capture module unavailable.')
+        return
+
+    cfg = job['config']
+    output_dir = Path(str(cfg['output_dir'])).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    mode = str(cfg['mode'])
+    try:
+        job['status'] = 'running'
+        job['step'] = 'Capturing stream URLs'
+        job['progress'] = 10
+        job['updated_at'] = _iso_now()
+        _append_job_log(job, f"Starting capture in {mode} mode.")
+        hits = passive_capture_module.capture_with_playwright(
+            str(cfg['url']),
+            int(cfg['capture_seconds']),
+            int(cfg['idle_seconds']),
+            bool(cfg['headless']),
+        )
+        job['progress'] = 55
+        job['step'] = f'Captured {len(hits)} stream candidates'
+        job['updated_at'] = _iso_now()
+        _append_job_log(job, f"Captured {len(hits)} stream candidates.")
+
+        if not bool(cfg['auto_download']):
+            job['status'] = 'done'
+            job['progress'] = 100
+            job['step'] = 'Capture complete (auto-download disabled)'
+            job['updated_at'] = _iso_now()
+            return
+
+        if not hits:
+            job['status'] = 'done'
+            job['progress'] = 100
+            job['step'] = 'No stream URLs discovered'
+            job['updated_at'] = _iso_now()
+            return
+
+        job['step'] = 'Downloading captured streams'
+        job['progress'] = 70
+        success, failed, debug = passive_capture_module.download_hits(hits, output_dir, mode)
+        job['result'] = {'success': success, 'failed': failed}
+        for line in debug:
+            _append_job_log(job, line)
+        job['progress'] = 100
+        job['updated_at'] = _iso_now()
+        if failed == 0:
+            job['status'] = 'done'
+            job['step'] = f'Download complete ({success} succeeded)'
+        else:
+            job['status'] = 'done'
+            job['step'] = f'Download complete ({success} succeeded, {failed} failed)'
+    except Exception as exc:  # pragma: no cover
+        job['status'] = 'failed'
+        job['progress'] = 100
+        job['step'] = 'Capture failed'
+        job['updated_at'] = _iso_now()
+        _append_job_log(job, f'Error: {exc}')
 
 def load_tools():
     """Load tool definitions from tools.json."""
@@ -295,42 +404,23 @@ def media_harvester():
 
             if values['passive_mode'] not in {'slow', 'fast', 'elusive-sites'}:
                 values['passive_mode'] = 'slow'
-
-            command = [
-                sys.executable,
-                str(MEDIA_PASSIVE_CAPTURE_SCRIPT),
-                '--output', values['passive_output_dir'],
-                '--mode', values['passive_mode'],
-                '--capture-seconds', values['passive_capture_seconds'],
-                '--idle-seconds', values['passive_idle_seconds'],
-            ]
-            if values['passive_page_url']:
-                command.extend(['--url', values['passive_page_url']])
-            if values['passive_headless']:
-                command.append('--headless')
-            if values['passive_auto_download']:
-                command.append('--auto-download')
-
-            try:
-                completed = subprocess.run(
-                    command,
-                    cwd=str(SCRIPTS_DIR),
-                    capture_output=True,
-                    text=True,
-                    timeout=60 * 20,
-                )
-                output = (completed.stdout or '') + ('\n' + completed.stderr if completed.stderr else '')
-                if completed.returncode == 0:
-                    flash('Passive capture completed.', 'success')
-                else:
-                    flash('Passive capture finished with errors. Review run output below.', 'error')
-            except subprocess.TimeoutExpired:
-                output = 'Passive capture timed out after 20 minutes.'
-                flash(output, 'error')
-            except Exception as exc:  # pragma: no cover
-                output = f'Failed to run passive capture: {exc}'
-                flash(output, 'error')
-
+            if not values['passive_page_url']:
+                flash('Please enter a player page URL for passive capture.', 'error')
+                return render_template('media_harvester.html', values=values, output=output)
+            payload = {
+                'url': values['passive_page_url'],
+                'output_dir': values['passive_output_dir'],
+                'mode': values['passive_mode'],
+                'capture_seconds': int(values['passive_capture_seconds']),
+                'idle_seconds': int(values['passive_idle_seconds']),
+                'headless': bool(values['passive_headless']),
+                'auto_download': bool(values['passive_auto_download']),
+            }
+            job_id = _create_passive_job(payload)
+            thread = threading.Thread(target=_run_passive_capture_job, args=(job_id,), daemon=True)
+            thread.start()
+            output = f'Passive capture job started: {job_id}'
+            flash('Passive capture started in background.', 'success')
             return render_template('media_harvester.html', values=values, output=output)
 
         values.update({
@@ -475,6 +565,39 @@ def media_harvester_check_tools():
     except Exception as exc:  # pragma: no cover
         flash(f'Failed to run tool check: {exc}', 'error')
     return redirect(url_for('media_harvester'))
+
+
+@app.post('/media-harvester/passive/start')
+def media_harvester_passive_start():
+    values = {
+        'url': request.form.get('passive_page_url', '').strip(),
+        'output_dir': request.form.get('passive_output_dir', str(SCRIPTS_DIR / 'media_downloads')).strip(),
+        'mode': request.form.get('passive_mode', 'slow').strip() or 'slow',
+        'capture_seconds': request.form.get('passive_capture_seconds', '90').strip() or '90',
+        'idle_seconds': request.form.get('passive_idle_seconds', '12').strip() or '12',
+        'headless': bool(request.form.get('passive_headless')),
+        'auto_download': bool(request.form.get('passive_auto_download')),
+    }
+    if not values['url']:
+        return jsonify({'ok': False, 'error': 'Missing passive page URL.'}), 400
+    if values['mode'] not in {'slow', 'fast', 'elusive-sites'}:
+        values['mode'] = 'slow'
+    try:
+        values['capture_seconds'] = max(20, int(str(values['capture_seconds'])))
+        values['idle_seconds'] = max(3, int(str(values['idle_seconds'])))
+    except ValueError:
+        return jsonify({'ok': False, 'error': 'Capture/idle values must be valid integers.'}), 400
+    job_id = _create_passive_job(values)
+    threading.Thread(target=_run_passive_capture_job, args=(job_id,), daemon=True).start()
+    return jsonify({'ok': True, 'job_id': job_id})
+
+
+@app.get('/media-harvester/passive/jobs')
+def media_harvester_passive_jobs():
+    with PASSIVE_CAPTURE_LOCK:
+        jobs = list(PASSIVE_CAPTURE_JOBS.values())
+    jobs.sort(key=lambda item: str(item.get('created_at', '')), reverse=True)
+    return jsonify({'jobs': jobs[:20]})
 
 
 @app.route('/csv-editor')

--- a/scripts/media_passive_capture.py
+++ b/scripts/media_passive_capture.py
@@ -12,6 +12,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 MEDIA_MARKERS = (
     ".m3u8",
@@ -107,28 +108,52 @@ def sanitize_filename(url: str, fallback: str) -> str:
 
 def run_yt_dlp(stream_url: str, output_dir: Path) -> tuple[bool, str]:
     output_template = str(output_dir / "%(title).120s_%(id)s.%(ext)s")
+    parsed = urlparse(stream_url)
+    referer = f"{parsed.scheme}://{parsed.netloc}/" if parsed.scheme and parsed.netloc else ""
     cmd = [
         sys.executable,
         "-m",
         "yt_dlp",
         "--no-overwrites",
         "--restrict-filenames",
+        "--socket-timeout",
+        "30",
+        "--retries",
+        "15",
+        "--fragment-retries",
+        "20",
+        "--retry-sleep",
+        "exp=1:8",
+        "--concurrent-fragments",
+        "8",
+        "--hls-prefer-native",
+        "--extractor-retries",
+        "6",
         "--output",
         output_template,
+        "--add-header",
+        "User-Agent:Mozilla/5.0",
         stream_url,
     ]
-    completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 15)
-    output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
-    return completed.returncode == 0, output[-2000:]
+    if referer:
+        cmd[cmd.index(stream_url):cmd.index(stream_url)] = ["--add-header", f"Referer:{referer}"]
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 30)
+        output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+        return completed.returncode == 0, output[-2000:]
+    except subprocess.TimeoutExpired as exc:
+        output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+        return False, f"yt-dlp timeout after 30m\n{output[-1800:]}"
 
 
 def run_yt_dlp_resilient(stream_url: str, output_dir: Path) -> tuple[bool, str]:
     """Attempt yt-dlp with fallback argument profiles for hard-to-fetch streams."""
     output_template = str(output_dir / "%(title).120s_%(id)s.%(ext)s")
     strategies = [
-        [],
-        ["--retries", "12", "--fragment-retries", "12", "--retry-sleep", "exp=1:8"],
-        ["--force-generic-extractor", "--retries", "12", "--fragment-retries", "12", "--retry-sleep", "exp=1:8"],
+        ["--hls-prefer-native"],
+        ["--hls-use-mpegts", "--downloader", "ffmpeg"],
+        ["--force-generic-extractor", "--hls-prefer-native"],
+        ["--force-generic-extractor", "--hls-use-mpegts", "--downloader", "ffmpeg"],
     ]
     failures: list[str] = []
     for extra_args in strategies:
@@ -138,18 +163,34 @@ def run_yt_dlp_resilient(stream_url: str, output_dir: Path) -> tuple[bool, str]:
             "yt_dlp",
             "--no-overwrites",
             "--restrict-filenames",
+            "--socket-timeout",
+            "30",
+            "--retries",
+            "18",
+            "--fragment-retries",
+            "24",
+            "--extractor-retries",
+            "8",
+            "--retry-sleep",
+            "exp=1:10",
             "--concurrent-fragments",
-            "6",
+            "8",
             "--output",
             output_template,
             *extra_args,
+            "--add-header",
+            "User-Agent:Mozilla/5.0",
             stream_url,
         ]
-        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 20)
-        output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
-        if completed.returncode == 0:
-            return True, output[-2000:]
-        failures.append(output[-450:] or "yt-dlp failed")
+        try:
+            completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 35)
+            output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+            if completed.returncode == 0:
+                return True, output[-2000:]
+            failures.append(output[-450:] or "yt-dlp failed")
+        except subprocess.TimeoutExpired as exc:
+            output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+            failures.append(f"yt-dlp timeout after 35m\n{output[-420:]}")
     return False, "\n---\n".join(failures)[-2500:]
 
 
@@ -158,15 +199,29 @@ def run_ffmpeg_passthrough(stream_url: str, output_dir: Path) -> tuple[bool, str
     cmd = [
         "ffmpeg",
         "-y",
+        "-protocol_whitelist",
+        "file,http,https,tcp,tls,crypto",
+        "-reconnect",
+        "1",
+        "-reconnect_streamed",
+        "1",
+        "-reconnect_delay_max",
+        "8",
         "-i",
         stream_url,
         "-c",
         "copy",
+        "-bsf:a",
+        "aac_adtstoasc",
         str(out_file),
     ]
-    completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 15)
-    output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
-    return completed.returncode == 0, output[-2000:]
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 25)
+        output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+        return completed.returncode == 0, output[-2000:]
+    except subprocess.TimeoutExpired as exc:
+        output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+        return False, f"ffmpeg copy timeout after 25m\n{output[-1800:]}"
 
 
 def run_ffmpeg_reencode(stream_url: str, output_dir: Path) -> tuple[bool, str]:
@@ -175,6 +230,14 @@ def run_ffmpeg_reencode(stream_url: str, output_dir: Path) -> tuple[bool, str]:
     cmd = [
         "ffmpeg",
         "-y",
+        "-protocol_whitelist",
+        "file,http,https,tcp,tls,crypto",
+        "-reconnect",
+        "1",
+        "-reconnect_streamed",
+        "1",
+        "-reconnect_delay_max",
+        "8",
         "-i",
         stream_url,
         "-c:v",
@@ -185,9 +248,13 @@ def run_ffmpeg_reencode(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         "aac",
         str(out_file),
     ]
-    completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 20)
-    output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
-    return completed.returncode == 0, output[-2000:]
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 30)
+        output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+        return completed.returncode == 0, output[-2000:]
+    except subprocess.TimeoutExpired as exc:
+        output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+        return False, f"ffmpeg reencode timeout after 30m\n{output[-1800:]}"
 
 
 def run_curl_fetch(stream_url: str, output_dir: Path) -> tuple[bool, str]:
@@ -202,15 +269,26 @@ def run_curl_fetch(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         "--fail",
         "--silent",
         "--show-error",
+        "--retry",
+        "8",
+        "--retry-all-errors",
+        "--retry-delay",
+        "1",
+        "--connect-timeout",
+        "20",
         "--output",
         str(out_file),
         stream_url,
     ]
-    completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 10)
-    output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
-    if completed.returncode == 0 and out_file.exists() and out_file.stat().st_size > 0:
-        return True, output[-2000:]
-    return False, output[-2000:] or "curl failed"
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, timeout=60 * 15)
+        output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+        if completed.returncode == 0 and out_file.exists() and out_file.stat().st_size > 0:
+            return True, output[-2000:]
+        return False, output[-2000:] or "curl failed"
+    except subprocess.TimeoutExpired as exc:
+        output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+        return False, f"curl timeout after 15m\n{output[-1800:]}"
 
 
 def download_hits(hits: list[StreamHit], output_dir: Path, mode: str) -> tuple[int, int, list[str]]:

--- a/static/style.css
+++ b/static/style.css
@@ -259,6 +259,28 @@ button:hover {
   box-shadow: 0 16px 32px rgba(79, 70, 229, 0.15);
 }
 
+.progress-track {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #4f46e5, #22c55e);
+  transition: width 0.4s ease;
+}
+
+.text-danger {
+  color: #b91c1c;
+}
+
+.text-success {
+  color: #166534;
+}
+
 .media-harvester-page .actions button {
   min-width: 220px;
 }

--- a/templates/media_harvester.html
+++ b/templates/media_harvester.html
@@ -140,7 +140,7 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
     <li>Review output logs to see intercepted stream URLs and download results.</li>
   </ol>
 
-  <form method="post" class="stack">
+  <form method="post" class="stack" id="passiveCaptureForm">
     <input type="hidden" name="workflow" value="passive">
     <div class="form-grid">
       <label>
@@ -187,9 +187,10 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
     </div>
 
     <div class="actions wrap-actions">
-      <button type="submit">Run Passive Capture</button>
+      <button type="submit" id="startPassiveCaptureBtn">Run Passive Capture</button>
     </div>
   </form>
+  <div id="passiveCaptureJobs" class="stack"></div>
 </section>
 
 {% if output %}
@@ -255,6 +256,67 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
     modeEl.addEventListener('change', sync);
     siteModeEl.addEventListener('change', sync);
     sync();
+  })();
+
+  (() => {
+    const form = document.getElementById('passiveCaptureForm');
+    const jobsWrap = document.getElementById('passiveCaptureJobs');
+    if (!form || !jobsWrap) return;
+
+    const renderJobs = (jobs) => {
+      if (!jobs.length) {
+        jobsWrap.innerHTML = '<p class="help-text">No passive capture jobs yet.</p>';
+        return;
+      }
+      jobsWrap.innerHTML = jobs.map((job) => {
+        const progress = Number(job.progress || 0);
+        const statusClass = job.status === 'failed' ? 'text-danger' : (job.status === 'done' ? 'text-success' : '');
+        const logs = (job.logs || []).slice(-8).join('\n');
+        return `
+          <section class="card">
+            <h4>Job ${job.id}</h4>
+            <p class="help-text ${statusClass}">${job.status} · ${job.step || ''}</p>
+            <div class="progress-track">
+              <div class="progress-fill" style="width:${Math.max(0, Math.min(100, progress))}%"></div>
+            </div>
+            <p class="help-text">${progress}% complete</p>
+            <pre class="logs-output">${logs || 'No logs yet.'}</pre>
+          </section>
+        `;
+      }).join('');
+    };
+
+    const loadJobs = async () => {
+      try {
+        const response = await fetch('{{ url_for("media_harvester_passive_jobs") }}');
+        if (!response.ok) return;
+        const data = await response.json();
+        renderJobs(data.jobs || []);
+      } catch (err) {
+        // keep silent; we'll retry on next poll
+      }
+    };
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      try {
+        const response = await fetch('{{ url_for("media_harvester_passive_start") }}', {
+          method: 'POST',
+          body: new FormData(form),
+        });
+        const data = await response.json();
+        if (!response.ok || !data.ok) {
+          alert(data.error || 'Failed to start passive capture job.');
+          return;
+        }
+        await loadJobs();
+      } catch (err) {
+        alert('Failed to start passive capture job.');
+      }
+    });
+
+    loadJobs();
+    setInterval(loadJobs, 2000);
   })();
 </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide a non-blocking passive capture workflow so each click on Run Passive Capture starts a separate job with its own progress and logs. 
- Allow multiple passive-capture jobs to run in parallel from the web UI. 
- Improve reliability for timeouts, HLS/m3u8 and other flaky stream sources by hardening the download pipeline.

### Description
- Added in-memory job orchestration to `app.py` including `_create_passive_job`, `_run_passive_capture_job`, job registry, locking, and timestamps, and wired background execution via `threading.Thread` so passive captures run asynchronously. 
- Exposed two new JSON endpoints: `POST /media-harvester/passive/start` to launch jobs and `GET /media-harvester/passive/jobs` to poll recent job state, and integrated these into the existing `/media-harvester` route. 
- Updated the passive-capture UI in `templates/media_harvester.html` to submit job starts via the new API, poll job status, and render per-job cards with a progress bar, status line and recent logs; added CSS (`static/style.css`) for `.progress-track`, `.progress-fill`, and status colors. 
- Hardened `scripts/media_passive_capture.py` download pipeline by adding `yt-dlp` timeout/retry/fragment/extractor options, HLS-specific strategies, automatic `Referer`/`User-Agent` headers, exception handling for `TimeoutExpired`, `ffmpeg` reconnect/protocol flags and audio bitstream filters, and `curl` retry/connect-timeout improvements for last-resort fetches.

### Testing
- Ran Python byte-compile checks: `python -m py_compile app.py scripts/media_passive_capture.py` and the files compiled successfully. 
- Smoke-validated that the new endpoints return job payloads and that the template JavaScript polls `GET /media-harvester/passive/jobs` (manual UI run not included in automated tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d914f0dbb883249f6a125c762ef8d1)