### PR TITLE
Passive capture: add per-field help, parallel-downloads option, and collision-safe per-hit isolation

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,7 +163,12 @@ def _run_passive_capture_job(job_id: str) -> None:
 
         job['step'] = 'Downloading captured streams'
         job['progress'] = 70
-        success, failed, debug = passive_capture_module.download_hits(hits, output_dir, mode)
+        try:
+            parallel_downloads = int(cfg.get('parallel_downloads', 3))
+        except (TypeError, ValueError):
+            parallel_downloads = 3
+        parallel_downloads = max(1, min(parallel_downloads, 12))
+        success, failed, debug = passive_capture_module.download_hits(hits, output_dir, mode, parallel_downloads)
         job['result'] = {'success': success, 'failed': failed}
         for line in debug:
             _append_job_log(job, line)
@@ -383,6 +388,7 @@ def media_harvester():
         'passive_mode': str(defaults.get('passive_mode', 'slow')),
         'passive_capture_seconds': str(defaults.get('passive_capture_seconds', '90')),
         'passive_idle_seconds': str(defaults.get('passive_idle_seconds', '12')),
+        'passive_parallel_downloads': str(defaults.get('passive_parallel_downloads', '3')),
         'passive_headless': '1' if defaults.get('passive_headless', True) else '',
         'passive_auto_download': '1' if defaults.get('passive_auto_download', True) else '',
     }
@@ -398,6 +404,7 @@ def media_harvester():
                 'passive_mode': request.form.get('passive_mode', values['passive_mode']).strip() or 'slow',
                 'passive_capture_seconds': request.form.get('passive_capture_seconds', values['passive_capture_seconds']).strip() or '90',
                 'passive_idle_seconds': request.form.get('passive_idle_seconds', values['passive_idle_seconds']).strip() or '12',
+                'passive_parallel_downloads': request.form.get('passive_parallel_downloads', values['passive_parallel_downloads']).strip() or '3',
                 'passive_headless': '1' if request.form.get('passive_headless') else '',
                 'passive_auto_download': '1' if request.form.get('passive_auto_download') else '',
             })
@@ -407,12 +414,23 @@ def media_harvester():
             if not values['passive_page_url']:
                 flash('Please enter a player page URL for passive capture.', 'error')
                 return render_template('media_harvester.html', values=values, output=output)
+            try:
+                capture_seconds = max(20, int(values['passive_capture_seconds']))
+                idle_seconds = max(3, int(values['passive_idle_seconds']))
+                parallel_downloads = max(1, min(12, int(values['passive_parallel_downloads'])))
+            except ValueError:
+                flash('Passive capture seconds, idle seconds, and parallel downloads must be integers.', 'error')
+                return render_template('media_harvester.html', values=values, output=output)
+            values['passive_capture_seconds'] = str(capture_seconds)
+            values['passive_idle_seconds'] = str(idle_seconds)
+            values['passive_parallel_downloads'] = str(parallel_downloads)
             payload = {
                 'url': values['passive_page_url'],
                 'output_dir': values['passive_output_dir'],
                 'mode': values['passive_mode'],
-                'capture_seconds': int(values['passive_capture_seconds']),
-                'idle_seconds': int(values['passive_idle_seconds']),
+                'capture_seconds': capture_seconds,
+                'idle_seconds': idle_seconds,
+                'parallel_downloads': parallel_downloads,
                 'headless': bool(values['passive_headless']),
                 'auto_download': bool(values['passive_auto_download']),
             }
@@ -465,6 +483,7 @@ def media_harvester():
                 'passive_mode': values['passive_mode'],
                 'passive_capture_seconds': values['passive_capture_seconds'],
                 'passive_idle_seconds': values['passive_idle_seconds'],
+                'passive_parallel_downloads': values['passive_parallel_downloads'],
                 'passive_headless': bool(values['passive_headless']),
                 'passive_auto_download': bool(values['passive_auto_download']),
             }
@@ -575,6 +594,7 @@ def media_harvester_passive_start():
         'mode': request.form.get('passive_mode', 'slow').strip() or 'slow',
         'capture_seconds': request.form.get('passive_capture_seconds', '90').strip() or '90',
         'idle_seconds': request.form.get('passive_idle_seconds', '12').strip() or '12',
+        'parallel_downloads': request.form.get('passive_parallel_downloads', '3').strip() or '3',
         'headless': bool(request.form.get('passive_headless')),
         'auto_download': bool(request.form.get('passive_auto_download')),
     }
@@ -585,8 +605,9 @@ def media_harvester_passive_start():
     try:
         values['capture_seconds'] = max(20, int(str(values['capture_seconds'])))
         values['idle_seconds'] = max(3, int(str(values['idle_seconds'])))
+        values['parallel_downloads'] = max(1, min(12, int(str(values['parallel_downloads']))))
     except ValueError:
-        return jsonify({'ok': False, 'error': 'Capture/idle values must be valid integers.'}), 400
+        return jsonify({'ok': False, 'error': 'Capture, idle, and parallel download values must be valid integers.'}), 400
     job_id = _create_passive_job(values)
     threading.Thread(target=_run_passive_capture_job, args=(job_id,), daemon=True).start()
     return jsonify({'ok': True, 'job_id': job_id})

--- a/scripts/media_passive_capture.py
+++ b/scripts/media_passive_capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import hashlib
 import re
 import shutil
 import subprocess
@@ -106,7 +107,15 @@ def sanitize_filename(url: str, fallback: str) -> str:
     return cleaned[:100] or fallback
 
 
-def run_yt_dlp(stream_url: str, output_dir: Path) -> tuple[bool, str]:
+def _download_identity(stream_url: str, work_id: str) -> tuple[str, Path]:
+    token = hashlib.sha1(stream_url.encode("utf-8")).hexdigest()[:10]
+    label = f"{work_id}_{token}"
+    work_dir = Path("work") / label
+    return label, work_dir
+
+
+def run_yt_dlp(stream_url: str, output_dir: Path, work_id: str = "job") -> tuple[bool, str]:
+    _, work_subdir = _download_identity(stream_url, work_id)
     output_template = str(output_dir / "%(title).120s_%(id)s.%(ext)s")
     parsed = urlparse(stream_url)
     referer = f"{parsed.scheme}://{parsed.netloc}/" if parsed.scheme and parsed.netloc else ""
@@ -126,6 +135,8 @@ def run_yt_dlp(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         "exp=1:8",
         "--concurrent-fragments",
         "8",
+        "--paths",
+        f"temp:{work_subdir.as_posix()}",
         "--hls-prefer-native",
         "--extractor-retries",
         "6",
@@ -146,8 +157,9 @@ def run_yt_dlp(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         return False, f"yt-dlp timeout after 30m\n{output[-1800:]}"
 
 
-def run_yt_dlp_resilient(stream_url: str, output_dir: Path) -> tuple[bool, str]:
+def run_yt_dlp_resilient(stream_url: str, output_dir: Path, work_id: str = "job") -> tuple[bool, str]:
     """Attempt yt-dlp with fallback argument profiles for hard-to-fetch streams."""
+    _, work_subdir = _download_identity(stream_url, work_id)
     output_template = str(output_dir / "%(title).120s_%(id)s.%(ext)s")
     strategies = [
         ["--hls-prefer-native"],
@@ -175,6 +187,8 @@ def run_yt_dlp_resilient(stream_url: str, output_dir: Path) -> tuple[bool, str]:
             "exp=1:10",
             "--concurrent-fragments",
             "8",
+            "--paths",
+            f"temp:{work_subdir.as_posix()}",
             "--output",
             output_template,
             *extra_args,
@@ -194,8 +208,9 @@ def run_yt_dlp_resilient(stream_url: str, output_dir: Path) -> tuple[bool, str]:
     return False, "\n---\n".join(failures)[-2500:]
 
 
-def run_ffmpeg_passthrough(stream_url: str, output_dir: Path) -> tuple[bool, str]:
-    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}.mp4"
+def run_ffmpeg_passthrough(stream_url: str, output_dir: Path, work_id: str = "job") -> tuple[bool, str]:
+    label, _ = _download_identity(stream_url, work_id)
+    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}_{label}.mp4"
     cmd = [
         "ffmpeg",
         "-y",
@@ -224,9 +239,10 @@ def run_ffmpeg_passthrough(stream_url: str, output_dir: Path) -> tuple[bool, str
         return False, f"ffmpeg copy timeout after 25m\n{output[-1800:]}"
 
 
-def run_ffmpeg_reencode(stream_url: str, output_dir: Path) -> tuple[bool, str]:
+def run_ffmpeg_reencode(stream_url: str, output_dir: Path, work_id: str = "job") -> tuple[bool, str]:
     """Fallback for snippet/fragment sources that fail stream copy."""
-    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}_reencode.mp4"
+    label, _ = _download_identity(stream_url, work_id)
+    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}_{label}_reencode.mp4"
     cmd = [
         "ffmpeg",
         "-y",
@@ -257,12 +273,13 @@ def run_ffmpeg_reencode(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         return False, f"ffmpeg reencode timeout after 30m\n{output[-1800:]}"
 
 
-def run_curl_fetch(stream_url: str, output_dir: Path) -> tuple[bool, str]:
+def run_curl_fetch(stream_url: str, output_dir: Path, work_id: str = "job") -> tuple[bool, str]:
     """Last-resort direct fetch for segment/snippet style URLs."""
     curl_path = shutil.which("curl")
     if not curl_path:
         return False, "curl not installed"
-    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}.bin"
+    label, _ = _download_identity(stream_url, work_id)
+    out_file = output_dir / f"{sanitize_filename(stream_url, 'stream_capture')}_{label}.bin"
     cmd = [
         curl_path,
         "-L",
@@ -291,7 +308,7 @@ def run_curl_fetch(stream_url: str, output_dir: Path) -> tuple[bool, str]:
         return False, f"curl timeout after 15m\n{output[-1800:]}"
 
 
-def download_hits(hits: list[StreamHit], output_dir: Path, mode: str) -> tuple[int, int, list[str]]:
+def download_hits(hits: list[StreamHit], output_dir: Path, mode: str, parallel_downloads: int = 3) -> tuple[int, int, list[str]]:
     debug: list[str] = []
     success = 0
     failed = 0
@@ -315,33 +332,36 @@ def download_hits(hits: list[StreamHit], output_dir: Path, mode: str) -> tuple[i
             key=lambda hit: 0 if any(token in hit.url.lower() for token in (".m3u8", ".mpd")) else 1,
         )
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+    max_workers = max(1, min(int(parallel_downloads), 12))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = []
-        for hit in targets:
+        for idx, hit in enumerate(targets, start=1):
+            work_id = f"hit{idx:03d}"
             if mode == "elusive-sites":
-                futures.append(pool.submit(run_yt_dlp_resilient, hit.url, output_dir))
+                futures.append(pool.submit(run_yt_dlp_resilient, hit.url, output_dir, work_id))
             else:
-                futures.append(pool.submit(run_yt_dlp, hit.url, output_dir))
+                futures.append(pool.submit(run_yt_dlp, hit.url, output_dir, work_id))
 
-        for hit, future in zip(targets, futures):
+        for idx, (hit, future) in enumerate(zip(targets, futures), start=1):
+            work_id = f"hit{idx:03d}"
             ok, msg = future.result()
             if ok:
                 success += 1
                 strategy = "yt-dlp resilient" if mode == "elusive-sites" else "yt-dlp"
                 debug.append(f"[OK] {strategy} -> {hit.url}")
                 continue
-            ff_ok, ff_msg = run_ffmpeg_passthrough(hit.url, output_dir)
+            ff_ok, ff_msg = run_ffmpeg_passthrough(hit.url, output_dir, work_id)
             if ff_ok:
                 success += 1
                 debug.append(f"[OK] ffmpeg copy -> {hit.url}")
             else:
                 if mode == "elusive-sites":
-                    reenc_ok, reenc_msg = run_ffmpeg_reencode(hit.url, output_dir)
+                    reenc_ok, reenc_msg = run_ffmpeg_reencode(hit.url, output_dir, work_id)
                     if reenc_ok:
                         success += 1
                         debug.append(f"[OK] ffmpeg reencode -> {hit.url}")
                         continue
-                    curl_ok, curl_msg = run_curl_fetch(hit.url, output_dir)
+                    curl_ok, curl_msg = run_curl_fetch(hit.url, output_dir, work_id)
                     if curl_ok:
                         success += 1
                         debug.append(f"[OK] curl fallback -> {hit.url}")
@@ -375,6 +395,12 @@ def main() -> int:
     parser.add_argument("--idle-seconds", type=int, default=12, help="Stop after this idle period once stream URLs are found")
     parser.add_argument("--headless", action="store_true", help="Run browser headless")
     parser.add_argument("--auto-download", action="store_true", help="Immediately download captured stream URLs")
+    parser.add_argument(
+        "--parallel-downloads",
+        type=int,
+        default=3,
+        help="Maximum simultaneous downloads (clamped to 1-12)",
+    )
     args = parser.parse_args()
 
     if not args.url:
@@ -402,7 +428,7 @@ def main() -> int:
         print("Auto-download disabled. Re-run with --auto-download to fetch captured streams.")
         return 0
 
-    success, failed, debug = download_hits(hits, out_dir, args.mode)
+    success, failed, debug = download_hits(hits, out_dir, args.mode, args.parallel_downloads)
     print("\n=== Download summary ===")
     print(f"Success: {success}")
     print(f"Failed : {failed}")

--- a/static/style.css
+++ b/static/style.css
@@ -298,3 +298,47 @@ button:hover {
 .btn-secondary:hover {
   background: #eef2ff;
 }
+
+.field-help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  border: 1px solid #c7d2fe;
+  color: #3730a3;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: help;
+  background: #eef2ff;
+}
+
+.field-help-popup {
+  position: absolute;
+  left: 1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  min-width: 230px;
+  max-width: 320px;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #c7d2fe;
+  background: #111827;
+  color: #e5e7eb;
+  box-shadow: 0 12px 30px rgba(17, 24, 39, 0.28);
+  line-height: 1.35;
+  font-size: 0.78rem;
+  font-weight: 500;
+  z-index: 40;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+}
+
+.field-help:hover .field-help-popup,
+.field-help:focus .field-help-popup,
+.field-help:focus-within .field-help-popup {
+  opacity: 1;
+}

--- a/templates/media_harvester.html
+++ b/templates/media_harvester.html
@@ -145,14 +145,26 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
     <div class="form-grid">
       <label>
         Player page URL
+        <span class="field-help" tabindex="0" aria-label="About player page URL">
+          ⓘ
+          <span class="field-help-popup">The page where playback happens. Changing this points capture to a different player/session context.</span>
+        </span>
         <input type="text" name="passive_page_url" value="{{ values.passive_page_url }}" placeholder="https://example.com/watch">
       </label>
       <label>
         Output folder
+        <span class="field-help" tabindex="0" aria-label="About output folder">
+          ⓘ
+          <span class="field-help-popup">Download destination for final files. Use a dedicated folder per project to keep runs isolated and easier to review.</span>
+        </span>
         <input type="text" name="passive_output_dir" value="{{ values.passive_output_dir }}">
       </label>
       <label>
         Passive mode
+        <span class="field-help" tabindex="0" aria-label="About passive mode">
+          ⓘ
+          <span class="field-help-popup">Slow captures while you play media. Fast prioritizes immediate full fetches. Elusive sites adds multiple fallback download methods.</span>
+        </span>
         <select name="passive_mode">
           <option value="slow" {% if values.passive_mode == 'slow' %}selected{% endif %}>Slow (playback mirroring)</option>
           <option value="fast" {% if values.passive_mode == 'fast' %}selected{% endif %}>Fast (request full stream)</option>
@@ -161,17 +173,37 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
       </label>
       <label>
         Capture seconds
+        <span class="field-help" tabindex="0" aria-label="About capture seconds">
+          ⓘ
+          <span class="field-help-popup">Max time spent watching network traffic for stream URLs. Higher values increase discovery chance but take longer.</span>
+        </span>
         <input type="number" min="20" step="1" name="passive_capture_seconds" value="{{ values.passive_capture_seconds }}">
       </label>
       <label>
         Idle stop seconds
+        <span class="field-help" tabindex="0" aria-label="About idle stop seconds">
+          ⓘ
+          <span class="field-help-popup">Stop early if no new stream URLs are seen. Lower values end sooner; higher values wait longer for late manifest requests.</span>
+        </span>
         <input type="number" min="3" step="1" name="passive_idle_seconds" value="{{ values.passive_idle_seconds }}">
+      </label>
+      <label>
+        Parallel downloads
+        <span class="field-help" tabindex="0" aria-label="About parallel downloads">
+          ⓘ
+          <span class="field-help-popup">How many captured streams to download at once (1-12). Higher values can speed up runs but use more bandwidth/CPU.</span>
+        </span>
+        <input type="number" min="1" max="12" step="1" name="passive_parallel_downloads" value="{{ values.passive_parallel_downloads }}">
       </label>
     </div>
 
     <div class="form-grid">
       <label>
         Headless browser
+        <span class="field-help" tabindex="0" aria-label="About headless browser">
+          ⓘ
+          <span class="field-help-popup">Enabled runs without showing a browser window. Disable when you need to manually interact with the player UI.</span>
+        </span>
         <select name="passive_headless">
           <option value="1" {% if values.passive_headless %}selected{% endif %}>Enabled</option>
           <option value="" {% if not values.passive_headless %}selected{% endif %}>Disabled</option>
@@ -179,6 +211,10 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
       </label>
       <label>
         Auto-download captured streams
+        <span class="field-help" tabindex="0" aria-label="About auto download">
+          ⓘ
+          <span class="field-help-popup">Enabled starts downloads immediately after capture. Disable to only collect stream candidates first.</span>
+        </span>
         <select name="passive_auto_download">
           <option value="1" {% if values.passive_auto_download %}selected{% endif %}>Enabled</option>
           <option value="" {% if not values.passive_auto_download %}selected{% endif %}>Disabled</option>


### PR DESCRIPTION
### Motivation
- Give users in-form guidance for each passive capture parameter so they understand implications while configuring runs. 
- Support multiple parallel downloads while preventing cross-job collisions between temp files and fallback outputs. 
- Make parallelism tunable and validate/clamp values server-side to avoid resource overload or invalid inputs.

### Description
- UI: added hover/info popup helpers for passive capture fields and a new `Parallel downloads` numeric input (1–12) in the passive capture form (templates/media_harvester.html) and supporting styles (static/style.css). 
- Backend (app.py): persisted `passive_parallel_downloads` in defaults, validated and clamped the value in both synchronous form submit and async job-start flows, and included `parallel_downloads` in the passive job payload. 
- Worker (scripts/media_passive_capture.py): introduced `_download_identity()` to generate a per-hit work label/subfolder and propagated a `work_id` parameter through download functions; configured `yt-dlp` to use per-work temp subfolders via `--paths temp:...`; made ffmpeg and curl fallback output filenames include the unique label; added `--parallel-downloads` CLI arg and made `download_hits()` accept and obey a `parallel_downloads` limit while assigning unique `work_id`s to concurrent tasks. 

### Testing
- Ran `python -m compileall app.py scripts/media_passive_capture.py` and compilation completed without errors. 
- No automated unit tests were present or executed beyond bytecode compilation in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9180525508324a24580738603b7da)