### PR TITLE
Improve Windows startup resilience across multiple Python installations

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,49 +1,108 @@
 @echo off
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 
-rem Ensure Python ignores user site-packages so installations stay isolated to the
-rem virtual environment and avoid permission issues with global packages.
-set PYTHONNOUSERSITE=1
-
-set "SCRIPT_DIR=%~dp0"
-cd /d "%SCRIPT_DIR%"
-set "VENV_DIR=%SCRIPT_DIR%.venv"
-set "PYTHON_EXE=%VENV_DIR%\Scripts\python.exe"
-
-rem Ensure installations always happen inside the virtual environment.
 set "PYTHONNOUSERSITE=1"
 set "PIP_USER=0"
 
-if not exist "%PYTHON_EXE%" (
-    echo Creating virtual environment...
-    py -3 -m venv "%VENV_DIR%" >nul 2>&1
-)
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+set "HELPER=%SCRIPT_DIR%start_bat_helper.py"
+set "SELF_BAT=%~f0"
+set "APP_PORT=5000"
 
-if not exist "%PYTHON_EXE%" (
-    python -m venv "%VENV_DIR%"
-)
-
-if not exist "%PYTHON_EXE%" (
-    echo Failed to create virtual environment. Ensure that Python 3 is installed and available in PATH.
+if not exist "%HELPER%" (
+    echo Missing helper script: "%HELPER%"
     exit /b 1
 )
 
-echo Updating pip...
-"%PYTHON_EXE%" -m pip install --upgrade pip
-if errorlevel 1 (
-    echo Failed to update pip. See the messages above for details.
-    exit /b 1
+set "CANDIDATES=;"
+
+rem Load persisted candidates from this batch file.
+for /f "tokens=2 delims==" %%P in ('findstr /b /c:"rem AUTO_CANDIDATE_PYTHON=" "%SELF_BAT%" 2^>nul') do (
+    call :add_candidate "%%~P"
 )
 
-echo Installing dependencies...
-"%PYTHON_EXE%" -m pip install -r requirements.txt
-if errorlevel 1 (
-    echo Failed to install dependencies. See the messages above for details.
-    exit /b 1
+rem Preferred local venv first.
+call :add_candidate "%SCRIPT_DIR%.venv\Scripts\python.exe"
+
+rem Add interpreters discovered through py launcher.
+call :add_py_launcher_candidate ""
+call :add_py_launcher_candidate "-3"
+call :add_py_launcher_candidate "-3.13"
+call :add_py_launcher_candidate "-3.12"
+call :add_py_launcher_candidate "-3.11"
+call :add_py_launcher_candidate "-3.10"
+call :add_py_launcher_candidate "-3.9"
+
+rem Add PATH python executables.
+for /f "usebackq delims=" %%P in (`where python 2^>nul`) do (
+    call :add_candidate "%%~fP"
 )
 
-start "OmniTool" "%PYTHON_EXE%" app.py
-timeout /t 3 > nul
-start "" http://localhost:5000
+call :try_candidates
+if not errorlevel 1 goto :opened
 
-endlocal
+echo.
+echo Initial candidates failed. Scanning "%SCRIPT_DIR%" and subfolders for python.exe...
+for /r "%SCRIPT_DIR%" %%F in (python.exe) do (
+    call :add_candidate "%%~fF"
+    call :remember_candidate "%%~fF"
+)
+
+call :try_candidates
+if not errorlevel 1 goto :opened
+
+echo.
+echo Failed to start OmniTool with every discovered Python environment.
+exit /b 1
+
+:opened
+echo Opening browser...
+start "" "http://localhost:%APP_PORT%"
+exit /b 0
+
+:add_py_launcher_candidate
+set "PYFLAG=%~1"
+set "PY_DISCOVERED="
+for /f "usebackq delims=" %%P in (`py %PYFLAG% -c "import sys; print(sys.executable)" 2^>nul`) do (
+    set "PY_DISCOVERED=%%~fP"
+)
+if defined PY_DISCOVERED call :add_candidate "!PY_DISCOVERED!"
+exit /b 0
+
+:add_candidate
+set "CANDIDATE=%~1"
+if not defined CANDIDATE exit /b 0
+if not exist "%CANDIDATE%" exit /b 0
+set "CANON=%~f1"
+set "NEEDLE=;!CANON!;"
+if not "!CANDIDATES:%NEEDLE%=!"=="!CANDIDATES!" exit /b 0
+set "CANDIDATES=!CANDIDATES!!CANON!;"
+exit /b 0
+
+:remember_candidate
+set "CANDIDATE=%~f1"
+if not exist "%CANDIDATE%" exit /b 0
+for /f "usebackq delims=" %%M in (`"%CANDIDATE%" "%HELPER%" --remember-candidate "%CANDIDATE%" "%SELF_BAT%" 2^>nul`) do (
+    rem no-op; helper prints status if needed.
+)
+exit /b 0
+
+:try_candidates
+set "WORKING_PYTHON="
+set "TO_TRY=!CANDIDATES:;= !"
+for %%P in (!TO_TRY!) do (
+    if exist "%%~fP" (
+        echo.
+        echo Trying Python interpreter: %%~fP
+        "%%~fP" "%HELPER%" --try-start --candidate "%%~fP" --script-dir "%SCRIPT_DIR%" --port %APP_PORT%
+        if not errorlevel 1 (
+            set "WORKING_PYTHON=%%~fP"
+            echo OmniTool started with: %%~fP
+            exit /b 0
+        )
+    )
+)
+exit /b 1
+
+rem AUTO_CANDIDATE_PYTHON=C:\Path\To\Python\python.exe

--- a/start_bat_helper.py
+++ b/start_bat_helper.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def safe_venv_name(candidate: Path) -> str:
+    digest = hashlib.sha1(str(candidate).lower().encode("utf-8")).hexdigest()[:10]
+    stem = candidate.parent.name.replace(" ", "_")
+    return f"{stem}_{digest}"
+
+
+def wait_for_port(host: str, port: int, timeout: int = 20) -> bool:
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(1)
+    return False
+
+
+def install_and_start(candidate: Path, script_dir: Path, port: int) -> int:
+    requirements = script_dir / "requirements.txt"
+    app_file = script_dir / "app.py"
+
+    if not app_file.exists():
+        print(f"app.py not found in {script_dir}")
+        return 1
+
+    venv_root = script_dir / ".venv_candidates"
+    venv_root.mkdir(parents=True, exist_ok=True)
+    venv_dir = venv_root / safe_venv_name(candidate)
+    py_exe = venv_dir / "Scripts" / "python.exe"
+
+    if not py_exe.exists():
+        print(f"Creating venv with {candidate} ...")
+        result = subprocess.run([str(candidate), "-m", "venv", str(venv_dir)], cwd=script_dir)
+        if result.returncode != 0 or not py_exe.exists():
+            print("Failed to create venv with this interpreter.")
+            return 1
+
+    print(f"Using venv interpreter: {py_exe}")
+    pip_upgrade = subprocess.run([str(py_exe), "-m", "pip", "install", "--upgrade", "pip"], cwd=script_dir)
+    if pip_upgrade.returncode != 0:
+        print("Failed to upgrade pip.")
+        return 1
+
+    if requirements.exists():
+        install_req = subprocess.run([str(py_exe), "-m", "pip", "install", "-r", str(requirements)], cwd=script_dir)
+        if install_req.returncode != 0:
+            print("Dependency installation failed.")
+            return 1
+
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NEW_CONSOLE
+
+    process = subprocess.Popen([str(py_exe), str(app_file)], cwd=script_dir, creationflags=creationflags)
+    if wait_for_port("127.0.0.1", port):
+        return 0
+
+    print("Server did not become healthy in time; stopping process.")
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+    return 1
+
+
+def remember_candidate(candidate: Path, bat_file: Path) -> int:
+    if not candidate.exists() or candidate.name.lower() != "python.exe":
+        return 0
+
+    marker = f"rem AUTO_CANDIDATE_PYTHON={candidate}"
+    try:
+        content = bat_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return 1
+
+    if marker.lower() in content.lower():
+        return 0
+
+    newline = "\r\n" if "\r\n" in content else "\n"
+    suffix = "" if content.endswith(("\n", "\r")) else newline
+    updated = f"{content}{suffix}{marker}{newline}"
+
+    try:
+        bat_file.write_text(updated, encoding="utf-8")
+    except OSError:
+        return 1
+
+    print(f"Saved candidate to batch file: {candidate}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--try-start", action="store_true")
+    parser.add_argument("--remember-candidate", action="store_true")
+    parser.add_argument("--candidate")
+    parser.add_argument("--script-dir")
+    parser.add_argument("--port", type=int, default=5000)
+    parser.add_argument("bat_file", nargs="?")
+    args = parser.parse_args()
+
+    if args.try_start:
+        if not args.candidate or not args.script_dir:
+            parser.error("--try-start needs --candidate and --script-dir")
+        return install_and_start(Path(args.candidate), Path(args.script_dir), args.port)
+
+    if args.remember_candidate:
+        if not args.candidate or not args.bat_file:
+            parser.error("--remember-candidate needs --candidate and bat_file")
+        return remember_candidate(Path(args.candidate), Path(args.bat_file))
+
+    parser.error("No action specified.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- The project must reliably start on Windows machines that have multiple or conflicting Python installations, so startup should try alternative interpreters and avoid dependency conflicts.
- A helper script is needed to create per-interpreter virtual environments, install dependencies and perform a health check before accepting an interpreter.

### Description
- Added `start_bat_helper.py` which creates per-candidate venvs under `.venv_candidates`, upgrades/installs dependencies from `requirements.txt`, starts `app.py`, probes `127.0.0.1:<port>` for health and tears down failed attempts cleanly.
- Reworked `start.bat` to set up helper variables, collect candidate interpreters from persisted `rem AUTO_CANDIDATE_PYTHON=...` lines, the local `.venv`, `py` launcher variants, and `where python` results, then try each candidate by invoking the helper.
- Implemented a fallback recursive scan under the project folder for `python.exe` when initial candidates fail and wired a persistence hook so discovered interpreters are appended to `start.bat` for future runs.
- Improved batch robustness (delayed expansion, candidate list handling) and ensured the browser is opened only when a working interpreter is found.

### Testing
- Compiled the helper module with `python -m py_compile start_bat_helper.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da910af7488324be49275d2f196f79)