### PR TITLE
Fix Dual File Renamer not showing folder picker

### DIFF
--- a/scripts/dual_file_renamer.py
+++ b/scripts/dual_file_renamer.py
@@ -22,8 +22,14 @@ THUMB_SIZE = 64 * 3
 def choose_directory(title: str) -> str:
     """Prompt the user to select a directory and return its path."""
     root = tk.Tk()
+    root.title("Dual File Renamer")
+    # Keep the picker on top so it does not end up hidden behind the launcher.
+    root.attributes("-topmost", True)
+    root.lift()
+    root.focus_force()
     root.withdraw()
-    folder = filedialog.askdirectory(title=title)
+    root.update_idletasks()
+    folder = filedialog.askdirectory(title=title, parent=root)
     root.destroy()
     return folder
 


### PR DESCRIPTION
### Motivation
- The folder picker could open hidden behind the launcher so the app reported it started but no dialog was visible, preventing users from selecting folders.

### Description
- Updated `choose_directory` in `scripts/dual_file_renamer.py` to set a temporary Tk root window title, make it topmost, lift and focus it, call `root.update_idletasks()`, and pass `parent=root` to `filedialog.askdirectory(...)` so the picker is explicitly parented and brought to the foreground.

### Testing
- Ran `python -m py_compile scripts/dual_file_renamer.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd14b17fd0832495fd77345a98b5ce)