### PR TITLE
Add YouTube-to-MP3 run mode to Media Harvester

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,6 +70,11 @@ def coerce_media_harvester_values(values):
     elif mode == 'download-all':
         values['include_page_with_ytdlp'] = '1'
         values['download_all_resolutions'] = '1'
+    elif mode == 'youtube-mp3':
+        values['include_page_with_ytdlp'] = '1'
+        values['download_all_resolutions'] = ''
+        values['all_page'] = ''
+        values['all_scroll'] = ''
 
     if site_mode == 'instagram-public':
         values['access_strategy'] = 'resilient'
@@ -463,6 +468,8 @@ def media_harvester():
             'site_mode': request.form.get('site_mode', values['site_mode']).strip() or 'general',
         })
 
+        if values['mode'] not in {'preview', 'download', 'download-all', 'youtube-mp3'}:
+            values['mode'] = 'preview'
         if values['access_strategy'] not in {'standard', 'resilient'}:
             values['access_strategy'] = 'standard'
         if values['site_mode'] not in {'general', 'instagram-public', 'all-media-html-sources'}:
@@ -525,6 +532,8 @@ def media_harvester():
                     command.append('--include-page-with-ytdlp')
                 if values['mode'] == 'download-all':
                     command.extend(['--include-page-with-ytdlp', '--download-all-resolutions'])
+                if values['mode'] == 'youtube-mp3':
+                    command.extend(['--extract-audio-mp3', '--include-page-with-ytdlp'])
                 if values['diagnostics']:
                     command.append('--diagnostics')
                 if values['download_all_resolutions'] and '--download-all-resolutions' not in command:

--- a/scripts/media_harvester.py
+++ b/scripts/media_harvester.py
@@ -646,6 +646,7 @@ def run_yt_dlp_with_strategies(
     proxy: str | None,
     access_strategy: str,
     site_mode: str,
+    extract_audio_mp3: bool = False,
     impersonation_targets: list[str] | None = None,
     allow_auto_install: bool = True,
 ) -> tuple[bool, str]:
@@ -659,7 +660,11 @@ def run_yt_dlp_with_strategies(
     if not cmd_prefix:
         return False, "yt-dlp not installed"
 
-    output_template = str(out_dir / "%(title).120s_%(id)s.%(ext)s")
+    output_template = (
+        str(out_dir / "%(title).120s_%(id)s.mp3")
+        if extract_audio_mp3
+        else str(out_dir / "%(title).120s_%(id)s.%(ext)s")
+    )
     base_cmd = cmd_prefix + [
         "--no-overwrites",
         "--no-playlist",
@@ -675,6 +680,8 @@ def run_yt_dlp_with_strategies(
         base_cmd.extend(["--merge-output-format", "mp4"])
     if proxy:
         base_cmd.extend(["--proxy", proxy])
+    if extract_audio_mp3:
+        base_cmd.extend(["--extract-audio", "--audio-format", "mp3", "--audio-quality", "0"])
     if site_mode == "instagram-public":
         base_cmd.extend(
             [
@@ -748,6 +755,7 @@ def run_yt_dlp_with_strategies(
                 proxy,
                 "resilient",
                 site_mode,
+                extract_audio_mp3=extract_audio_mp3,
                 impersonation_targets=refreshed_targets,
                 allow_auto_install=False,
             )
@@ -954,6 +962,7 @@ def main() -> int:
         help="Authorized access strategy for yt-dlp (resilient adds retries and browser impersonation).",
     )
     parser.add_argument("--save-defaults", action="store_true", help="Save current options as defaults")
+    parser.add_argument("--extract-audio-mp3", action="store_true", help="Use yt-dlp to convert target URL media to MP3")
     args = parser.parse_args()
 
     if args.save_defaults:
@@ -1031,6 +1040,29 @@ def main() -> int:
 
     out_dir = Path(args.output).expanduser().resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.extract_audio_mp3:
+        ok, msg = run_yt_dlp_with_strategies(
+            args.url,
+            out_dir,
+            max(args.timeout * 2, 90),
+            args.proxy,
+            args.access_strategy,
+            args.site_mode,
+            extract_audio_mp3=True,
+        )
+        print("\n=== Summary ===")
+        print(f"Output folder : {out_dir}")
+        print(f"Successful    : {1 if ok else 0}")
+        print(f"Failed        : {0 if ok else 1}")
+        if ok:
+            print(f"[OK] page-url -> {msg}")
+            return 0
+        print(f"[FAIL] page-url -> {msg}")
+        tip = suggest_authorized_next_steps(msg)
+        if tip:
+            print(tip)
+        return 2
 
     include_all_html_media = args.site_mode == "all-media-html-sources"
     session = build_session(proxy=args.proxy, timeout=args.timeout, site_mode=args.site_mode)

--- a/templates/media_harvester.html
+++ b/templates/media_harvester.html
@@ -56,6 +56,7 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
           <option value="preview" {% if values.mode == 'preview' %}selected{% endif %}>Preview only</option>
           <option value="download" {% if values.mode == 'download' %}selected{% endif %}>Standard download</option>
           <option value="download-all" {% if values.mode == 'download-all' %}selected{% endif %}>Download all available resolutions</option>
+          <option value="youtube-mp3" {% if values.mode == 'youtube-mp3' %}selected{% endif %}>YouTube to MP3</option>
         </select>
       </label>
       <label>
@@ -283,6 +284,10 @@ https://example.com/page-two">{{ values.urls_text }}</textarea>
           setSelectState(includePageEl, { disabled: false });
         }
         setSelectState(allResEl, { disabled: true, forcedValue: '' });
+      } else if (mode === 'youtube-mp3') {
+        setSelectState(includePageEl, { disabled: true, forcedValue: '1' });
+        setSelectState(allResEl, { disabled: true, forcedValue: '' });
+        setSelectState(allPageEl, { disabled: true, forcedValue: '' });
       } else {
         setSelectState(includePageEl, { disabled: true, forcedValue: '1' });
         setSelectState(allResEl, { disabled: true, forcedValue: '1' });


### PR DESCRIPTION
### Motivation
- Provide a dedicated, predictable workflow for converting one or multiple YouTube (and similar) links to MP3 so users can paste links and receive MP3 output without manual post-processing.

### Description
- Add a new `YouTube to MP3` run mode in the UI and include it in the run-mode selector so users can choose the mode from the frontend (`templates/media_harvester.html`).
- Update frontend JS to force appropriate toggles for the `youtube-mp3` mode (enable page-level `yt-dlp`, disable resolution/page-scan options) so behavior is deterministic (`templates/media_harvester.html`).
- Wire backend mode coercion and command construction to accept `youtube-mp3` and pass a new CLI flag to the harvester for each URL processed from the multi-URL input (`app.py`).
- Extend `scripts/media_harvester.py` with a `--extract-audio-mp3` flag and add `extract_audio_mp3` support to `run_yt_dlp_with_strategies`, which sets an MP3 output template and yt-dlp extraction arguments (`--extract-audio --audio-format mp3 --audio-quality 0`); add a fast-path CLI branch that runs yt-dlp audio extraction and prints a short summary when the flag is used.

### Testing
- Ran `python -m py_compile app.py scripts/media_harvester.py` which completed without errors.
- Ran `python scripts/media_harvester.py --help` to verify the new `--extract-audio-mp3` option appears in CLI help and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7650dbf4c83249ae87fc4aec01a68)