### PR TITLE
YouTube-to-MP3: remove video ID from MP3 filenames

### DIFF
--- a/scripts/media_harvester.py
+++ b/scripts/media_harvester.py
@@ -661,7 +661,7 @@ def run_yt_dlp_with_strategies(
         return False, "yt-dlp not installed"
 
     output_template = (
-        str(out_dir / "%(title).120s_%(id)s.mp3")
+        str(out_dir / "%(title).120s.mp3")
         if extract_audio_mp3
         else str(out_dir / "%(title).120s_%(id)s.%(ext)s")
     )


### PR DESCRIPTION
### Motivation
- MP3 downloads were being named with the sanitized title plus the YouTube video ID (e.g., `Hey_Mom_Its_Bryans_eIIWyoy4rF8.mp3`), and the intent is to produce MP3 files named only by the sanitized video title.

### Description
- Updated the `output_template` in `run_yt_dlp_with_strategies` so that when `extract_audio_mp3` is true it uses `str(out_dir / "%(title).120s.mp3")`, while leaving non-MP3 naming as `%(title).120s_%(id)s.%(ext)s`.

### Testing
- Ran `python -m py_compile scripts/media_harvester.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76fa5d7b8832484fd7b3bbdf20fec)